### PR TITLE
Add working first implementations of AsyncIterator and AsyncIterable

### DIFF
--- a/asynciterable.js
+++ b/asynciterable.js
@@ -7,7 +7,7 @@ var $asyncIterator$ = require('./symbol').asyncIterator;
 var bindCallback = require('./internal/bindcallback');
 
 function AsyncIterable(source) {
-  if (typeof source[$asyncIterator$] !== 'function') {
+  if (source && typeof source[$asyncIterator$] !== 'function') {
     throw new TypeError('Source must support Symbol.asyncIterator');
   }
   this._source = source;
@@ -38,6 +38,22 @@ AsyncIterable.prototype.forEachAsync = function (fn, thisArg) {
   recurse();
 
   return p;
+};
+
+AsyncIterable.addToObject = function (operators) {
+  Object.keys(operators).forEach(function (operator) {
+    AsyncIterable[operator] = operators[operator];
+  });
+};
+
+AsyncIterable.addToPrototype = function (operators) {
+  Object.keys(operators).forEach(function (operator) {
+    AsyncIterable.prototype[operator] = function () {
+      var args = [this];
+      args.push.apply(args, arguments);
+      return operators[operator].apply(null, args);
+    };
+  });
 };
 
 module.exports = AsyncIterable;

--- a/asynciterable/from.js
+++ b/asynciterable/from.js
@@ -3,87 +3,61 @@
 var AsyncIterable = require('../asynciterable');
 var AsyncIterator = require('../asynciterator');
 var $asyncIterator$ = require('../symbol').asyncIterator;
+var $iterator$ = require('../symbol').iterator;
+var bindCallback = require('../internal/bindcallback');
+var isIterable = require('../internal/isiterable');
+var toLength = require('../internal/tolength');
 var inherits = require('inherits');
 
-function AsyncFromIterator(gen) {
-  this._gen = gen;
-  this._current = null;
-  this._queue = [];
+function AsyncFromIterator(source, fn) {
+  AsyncIterator.call(this);
+  var iterable = isIterable(source);
+  this._source = source;
+  this._isIterable = iterable;
+  this._it = iterable ? source[$iterator$]() : null;
+  this._fn = fn;
+  this._i = 0;
 }
 
 inherits(AsyncFromIterator, AsyncIterator);
 
-['next', 'throw', 'return'].forEach(function (method) {
-  AsyncFromIterator.prototype[method] = function (value) {
-    this._enqueue(method, value);
-  };
-});
-
-AsyncFromIterator.prototype._enqueue = function (type, value) {
-  var self = this;
-  return new Promise(function (resolve, reject) {
-    self.queue.push({
-      type: type,
-      value: value,
-      resolve: resolve,
-      reject: reject
-    });
-    self._next();
-  });
-};
-
 AsyncFromIterator.prototype._next = function () {
-  if (this._current || this._queue.length === 0) { return; }
-  this._current = this._queue.shift();
-  this._resume(this._current.type, this._current.value);
-};
-
-AsyncFromIterator.prototype._settle = function (type, value) {
-  var capability = this._current;
-  this._current = null;
-  switch (type) {
-    case 'throw':
-      capability.reject(value);
-      break;
-    case 'return':
-      capability.resolve({done: true, value: value });
-      break;
-    default:
-      capability.resolve({done: false, value: value });
-      break;
-  }
-
-  this._next();
-};
-
-AsyncFromIterator.prototype._resume = function (type, value) {
-  var self = this;
-  try {
-    var result = this._gen[type](value);
-    if (isIterAwaitResultObject(result)) {
-      Promise.resolve(result.value).then(
-        function (x) { self._resume('next', x); },
-        function (x) { self._resume('throw, x'; )}
-      );
-    } else {
-      this._settle(result.done ? 'return' : 'normal', x);
+  var value;
+  if (this._isIterable) {
+    var next = this._it.next();
+    if (next.done) {
+      return this._settle('return', undefined);
     }
-  } catch (e) {
-    this._settle('throw', e);
+    value = next.value;
+    if (this._fn) {
+      value = this._fn(value, this._i++);
+    }
+  } else {
+    var length = toLength(this._source.length);
+    if (this._i >= length) {
+      return this._settle('return', undefined);
+    }
+    value = this._source[this._i];
+    if (this._fn) {
+      value = this._fn(value, this._i);
+    }
+    this._i++;
   }
+  this._settle('normal', value);
 };
 
-function AsyncFromIterable(gen) {
-  this._gen = gen;
+function AsyncFromIterable(source, fn, thisArg) {
   AsyncIterable.call(this);
+  this._source = source;
+  this._fn = bindCallback(fn, thisArg, 2);
 }
 
 inherits(AsyncFromIterable, AsyncIterable);
 
 AsyncFromIterable.prototype[$asyncIterator$] = function () {
-  return new AsyncFromIterator(this._gen);
+  return new AsyncFromIterator(this._source, this._fn);
 };
 
-module.exports = function fromGen (gen) {
-
+module.exports = function from (source, fn, thisArg) {
+  return new AsyncFromIterable(source, fn, thisArg);
 };

--- a/asynciterable/map.js
+++ b/asynciterable/map.js
@@ -1,30 +1,39 @@
 'use strict';
 
-var AsyncIterable = require('../iterable');
-var AsyncIterator = require('../iterator');
-var $asyncIterator$ = require('../symbol').iterator;
+var AsyncIterable = require('../AsyncIterable');
+var AsyncIterator = require('../AsyncIterator');
+var $asyncIterator$ = require('../symbol').asyncIterator;
 var bindCallback = require('../internal/bindcallback');
 var doneIterator = require('../internal/doneIterator');
 var inherits = require('inherits');
 
 function AsyncMapIterator(it, fn) {
+  AsyncIterator.call(this);
   this._it = it;
   this._fn = fn;
   this._i = 0;
-  AsyncIterator.call(this);
 }
 
 inherits(AsyncMapIterator, AsyncIterator);
 
-AsyncMapIterator.prototype.next = function () {
-  return Promise.resolve(doneIterator);
+AsyncMapIterator.prototype._next = function () {
+  var self = this;
+  this._it.next().then(function (next) {
+    if (next.done) { return self._settle('return', next.value); }
+    self._settle('normal', self._fn(next.value, self._i++));
+  }).catch(function (error) {
+    self._settle('throw', error);
+  });
 };
 
+function innerMap(fn, self) {
+  return function (x, i) { return fn.call(this, self._fn(x, i), i); };
+}
 
 function AsyncMapIterable(source, fn, thisArg) {
+  AsyncIterable.call(this);
   this._source = source;
   this._fn = bindCallback(fn, thisArg, 2);
-  AsyncIterable.call(this);
 }
 
 inherits(AsyncMapIterable, AsyncIterable);
@@ -33,6 +42,12 @@ AsyncMapIterable.prototype[$asyncIterator$] = function () {
   return new AsyncMapIterator(this._source[$asyncIterator$](), this._fn);
 };
 
+AsyncMapIterable.prototype.internalMap = function (fn, thisArg) {
+  return new AsyncMapIterable(this._source, innerMap(fn, this), thisArg);
+};
+
 module.exports = function map (source, fn, thisArg) {
-  return new AsyncMapIterable(source, fn, thisArg);
+  return source instanceof AsyncMapIterable ?
+    source.internalMap(fn, thisArg) :
+    new AsyncMapIterable(source, fn, thisArg);
 };

--- a/asynciterator.js
+++ b/asynciterator.js
@@ -3,15 +3,83 @@
 var $asyncIterator$ = require('./symbol').asyncIterator;
 
 function AsyncIterator() {
-
+  this._queue = [];
+  this._current = null;
 }
 
 AsyncIterator.prototype[$asyncIterator$] = function () {
   return this;
 };
 
-AsyncIterator.prototype.next = function () {
-  throw new Error('must be implemented');
+AsyncIterator.prototype._enqueue = function (type, value) {
+  var self = this;
+  return new Promise(function (resolve, reject) {
+    self._queue.push({
+      type: type,
+      value: value,
+      resolve: resolve,
+      reject: reject
+    });
+    self._resume();
+  });
+};
+
+AsyncIterator.prototype.next = function (value) {
+  return this._enqueue('next', value);
+};
+
+AsyncIterator.prototype._resume = function () {
+  if (this._current || this._queue.length === 0) {
+    return;
+  }
+  this._current = this._queue.shift();
+  try {
+    switch (this._current.type) {
+      case 'throw':
+        this._throw(this._current.value);
+        break;
+      case 'return':
+        this._return(this._current.value);
+        break;
+      default:
+        this._next(this._current.value);
+        break;
+    }
+  } catch (error) {
+    this._settle('throw', error);
+  }
+};
+
+AsyncIterator.prototype._throw = function (error) {
+  this._settle('throw', error);
+};
+
+AsyncIterator.prototype._return = function (value) {
+  this._settle('return', value);
+};
+
+AsyncIterator.prototype._settle = function (type, value) {
+  var self = this;
+  Promise.resolve(value).then(function (value) {
+    var capability = self._current;
+    self._current = null;
+    switch (type) {
+      case 'throw':
+        capability.reject(value);
+        break;
+      case 'return':
+        capability.resolve({ done: true, value: value });
+        break;
+      default:
+        capability.resolve({ done: false, value: value });
+        break;
+    }
+    self._resume();
+  }, function (error) {
+    self._current.reject(error);
+    self._current = null;
+    self._resume();
+  });
 };
 
 module.exports = AsyncIterator;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var Iterable = require('./iterable');
+var AsyncIterable = require('./asynciterable');
 
 Iterable.addToObject({
   from: require('./iterable/from'),
@@ -21,7 +22,17 @@ Iterable.addToPrototype({
   tap: require('./iterable/tap')
 });
 
+AsyncIterable.addToObject({
+    from: require('./asynciterable/from')
+});
+
+AsyncIterable.addToPrototype({
+    map: require('./asynciterable/map')
+});
+
 module.exports = {
   Iterator: require('./iterator'),
   Iterable: Iterable,
+  AsyncIterator: require('./asynciterator'),
+  AsyncIterable: AsyncIterable
 };

--- a/internal/isiterable.js
+++ b/internal/isiterable.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var $iterator$ = require('../symbol').iterable;
+var $iterator$ = require('../symbol').iterator;
 
 module.exports = function isIterable(x) {
   return x != null && Object(x) === x && typeof x[$iterator$] !== 'undefined';


### PR DESCRIPTION
There's still a lot of roughness here.  We'll need to update the subclassing interface to make things more ergonomic, for example.  Also, `from` only converts from synchronous iterables.  We'll of course want to adapt raw async iterables as well.