### PR TITLE
chore(package): setup initial build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ coverage
 
 # Compiled binary addons (http://nodejs.org/api/addons.html)
 build/Release
+dist
 
 # Dependency directory
 node_modules

--- a/package.json
+++ b/package.json
@@ -2,8 +2,31 @@
   "name": "ix",
   "version": "2.0.0",
   "description": "The Interactive Extensions for JavaScript",
+  "config": {
+    "commitizen": {
+      "path": "cz-conventional-changelog"
+    }
+  },
+  "lint-staged": {
+    "*.@(ts)": [
+      "tslint --fix",
+      "git add"
+    ]
+  },
   "scripts": {
-    "test": "tape test/**/*.js | tap-spec"
+    "info": "npm-scripts-info",
+    "?commit": "Run commit wizard",
+    "commit": "git-cz",
+    "?build:commonjs": "Build against CommonJS target",
+    "build:commonjs": "tsc -p tsconfig_commonjs.json",
+    "?build:es2015": "Build against native ES2015 target",
+    "build:es2015": "tsc -p tsconfig_es2015.json",
+    "build": "shx rm -rf ./dist/ && npm-run-all build:*",
+    "?lint:src": "Run lint against source files only",
+    "lint:src": "tslint -c tslint.json \"src/**/*.ts\"",
+    "?lint": "Run lint against files",
+    "lint": "npm-run-all --parallel lint:*",
+    "test": "ts-node node_modules/tape/bin/tape test/**/*.ts | tap-spec"
   },
   "repository": {
     "type": "git",
@@ -25,8 +48,19 @@
     "npm": ">=2.0.0"
   },
   "devDependencies": {
+    "commitizen": "^2.9.6",
+    "cz-conventional-changelog": "^2.0.0",
+    "husky": "^0.13.1",
+    "lint-staged": "^3.3.1",
+    "npm-run-all": "^4.0.2",
+    "npm-scripts-info": "^0.3.6",
+    "shx": "^0.2.2",
+    "tap-spec": "^4.1.1",
     "tape": "^4.6.3",
+    "ts-node": "^2.1.0",
+    "tslint": "^4.5.0",
     "typescript": "^2.1.5",
     "webpack": "^1.14.0"
-  }
+  },
+  "dependencies": {}
 }

--- a/tsconfig_base.json
+++ b/tsconfig_base.json
@@ -1,0 +1,26 @@
+//Common compiler configuration being used over different build targets.
+//This configuration can't be used to compile source code directly, use specific tsconfig_* build config.
+{
+  "compilerOptions": {
+    "removeComments": false,
+    "preserveConstEnums": true,
+    "sourceMap": true,
+    "declaration": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "suppressImplicitAnyIndexErrors": true,
+    "strictNullChecks": true,
+    "noUnusedLocals": true,
+    "noImplicitThis": true,
+    "noUnusedParameters": true,
+    "typeRoots" : ["./node_modules/@types"]
+  },
+  "formatCodeOptions": {
+    "indentSize": 2,
+    "tabSize": 2
+  },
+  "exclude": [
+    "node_modules",
+    "dist"
+  ]
+}

--- a/tsconfig_commonjs.json
+++ b/tsconfig_commonjs.json
@@ -1,0 +1,10 @@
+//Compiler configuaration to build against CommonJS module.
+{
+  "extends": "./tsconfig_base.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "target": "es5",
+    "outDir": "dist/cjs"
+  }
+}

--- a/tsconfig_es2015.json
+++ b/tsconfig_es2015.json
@@ -1,0 +1,10 @@
+//Compiler configuaration to build against native ES2015 module.
+{
+  "extends": "./tsconfig_base.json",
+  "compilerOptions": {
+    "module": "ES2015",
+    "moduleResolution": "node",
+    "target": "ES2015",
+    "outDir": "dist/es2015"
+  }
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,39 @@
+{
+  "rules": {
+    "curly": true,
+    "eofline": false,
+    "align": [true, "parameters"],
+    "class-name": true,
+    "indent": [true, "spaces"],
+    "max-line-length": [true, 150],
+    "no-consecutive-blank-lines": [true],
+    "no-trailing-whitespace": true,
+    "no-duplicate-variable": true,
+    "no-var-keyword": true,
+    "no-empty": true,
+    "no-unused-expression": true,
+    "no-use-before-declare": true,
+    "no-var-requires": true,
+    "no-require-imports": true,
+    "one-line": [true,
+      "check-else",
+      "check-whitespace",
+      "check-open-brace"],
+    "quotemark": [true,
+      "single",
+      "avoid-escape"],
+    "semicolon": [true, "always"],
+    "typedef-whitespace": [true, {
+      "call-signature": "nospace",
+      "index-signature": "nospace",
+      "parameter": "nospace",
+      "property-declaration": "nospace",
+      "variable-declaration": "nospace"
+    }],
+    "whitespace": [true,
+      "check-branch",
+      "check-decl",
+      "check-operator",
+      "check-type"]
+  }
+}


### PR DESCRIPTION
This PR setup initial build scripts, as well as arbitrary configurations. 

**What's included**

1. build scripts
- `build:commonjs` : build CommonJS target
- `build:es2015` : build native ES2015 target
- `build` : run all builds at once. This script does wildcard matching, so any `build:${target}` type script being added in further will be triggered as well.

2. lint script
- `lint:src` : run lint against source code
- `lint` : run lint against all code (in further). as same as build script, it does wildcard matching.

3. update test script
- invoke tape with `ts-node` to allow write test case in typescript.

4. convenient script
- `commit` : run `commitizen`, commit message wizard
- `info` : display currently available script with simple description.

5. lint-staged / husky for commit hook
: installed only due to below 

**What's not included**
1. actual build
: running compiler emits several compilation error at this moment, did not touch any codes.

2. setting up git precommit / prepush hook (lint-staged / husky)
: since build is currently failing, settings hook will block any further commits.