### PR TITLE
Rename IterableImpl -> IterableX to match ReactiveX

### DIFF
--- a/src/Ix.ts
+++ b/src/Ix.ts
@@ -1,7 +1,7 @@
 'use strict';
 
-export { IterableImpl as Iterable } from './iterable';
-export { IteratorImpl as Iterator } from './iterator';
+export { IterableX as Iterable } from './iterable';
+export { IteratorX as Iterator } from './iterator';
 
 // statics
 /* tslint:disable:no-use-before-declare */

--- a/src/add/iterable-operators/average.ts
+++ b/src/add/iterable-operators/average.ts
@@ -1,13 +1,13 @@
-import { IterableImpl } from '../../iterable';
+import { IterableX } from '../../iterable';
 import { average } from '../../iterable/average';
 
-function averageProto<T>(this: IterableImpl<T>, fn?: (value: T) => number) {
+function averageProto<T>(this: IterableX<T>, fn?: (value: T) => number) {
   return average<T>(this, fn);
 };
-IterableImpl.prototype.average = averageProto;
+IterableX.prototype.average = averageProto;
 
 declare module '../../Iterable' {
-  interface IterableImpl<T> {
+  interface IterableX<T> {
     average: typeof averageProto;
   }
 }

--- a/src/add/iterable-operators/buffer.ts
+++ b/src/add/iterable-operators/buffer.ts
@@ -1,14 +1,14 @@
-import { IterableImpl } from '../../iterable';
+import { IterableX } from '../../iterable';
 import { buffer } from '../../iterable/buffer';
 
-function bufferProto <T>(this: IterableImpl<T>, count: number, skip?: number): IterableImpl<T[]> {
+function bufferProto <T>(this: IterableX<T>, count: number, skip?: number): IterableX<T[]> {
   return buffer<T>(this, count, skip);
 };
 
-IterableImpl.prototype.buffer = bufferProto;
+IterableX.prototype.buffer = bufferProto;
 
 declare module '../../Iterable' {
-  interface IterableImpl<T> {
+  interface IterableX<T> {
     buffer: typeof bufferProto;
   }
 }

--- a/src/add/iterable-operators/catch.ts
+++ b/src/add/iterable-operators/catch.ts
@@ -1,14 +1,14 @@
-import { IterableImpl } from '../../iterable';
+import { IterableX } from '../../iterable';
 import { _catch } from '../../iterable/catch';
 
-function _catchProto<T>(this: IterableImpl<T>, fn: (error: any) => Iterable<T>): Iterable<T> {
+function _catchProto<T>(this: IterableX<T>, fn: (error: any) => Iterable<T>): Iterable<T> {
   return _catch<T>(this, fn);
 };
 
-IterableImpl.prototype.catch = _catchProto;
+IterableX.prototype.catch = _catchProto;
 
 declare module '../../Iterable' {
-  interface IterableImpl<T> {
+  interface IterableX<T> {
     catch: typeof _catchProto;
   }
 }

--- a/src/add/iterable-operators/catchall.ts
+++ b/src/add/iterable-operators/catchall.ts
@@ -1,13 +1,13 @@
-import { IterableImpl } from '../../iterable';
+import { IterableX } from '../../iterable';
 import { catchAll } from '../../iterable/catchall';
 
-function catchAllProto<T>(this: IterableImpl<T>, ...args: Iterable<T>[]): Iterable<T> {
+function catchAllProto<T>(this: IterableX<T>, ...args: Iterable<T>[]): Iterable<T> {
   return catchAll<T>(this, ...args);
 };
-IterableImpl.prototype.catchAll = catchAllProto;
+IterableX.prototype.catchAll = catchAllProto;
 
 declare module '../../Iterable' {
-  interface IterableImpl<T> {
+  interface IterableX<T> {
     catchAll: typeof catchAllProto;
   }
 }

--- a/src/add/iterable-operators/concat.ts
+++ b/src/add/iterable-operators/concat.ts
@@ -1,13 +1,13 @@
-import { IterableImpl } from '../../iterable';
+import { IterableX } from '../../iterable';
 import { concat } from '../../iterable/concat';
 
-function concatProto<T>(this: IterableImpl<T>, ...args: Iterable<T>[]) {
+function concatProto<T>(this: IterableX<T>, ...args: Iterable<T>[]) {
   return concat(this, ...args);
 }
-IterableImpl.prototype.concat =concatProto;
+IterableX.prototype.concat =concatProto;
 
 declare module '../../Iterable' {
-  interface IterableImpl<T> {
+  interface IterableX<T> {
     concat: typeof concatProto;
   }
 }

--- a/src/add/iterable-operators/filter.ts
+++ b/src/add/iterable-operators/filter.ts
@@ -1,14 +1,14 @@
-import { IterableImpl } from '../../iterable';
+import { IterableX } from '../../iterable';
 import { filter } from '../../iterable/filter';
 
-function filterProto<T>(this: IterableImpl<T>, fn: (value: T, index: number) => boolean, thisArg?: any): Iterable<T> {
+function filterProto<T>(this: IterableX<T>, fn: (value: T, index: number) => boolean, thisArg?: any): Iterable<T> {
   return filter(this, fn, thisArg);
 };
 
-IterableImpl.prototype.filter = filterProto;
+IterableX.prototype.filter = filterProto;
 
 declare module '../../Iterable' {
-  interface IterableImpl<T> {
+  interface IterableX<T> {
     filter: typeof filterProto;
   }
 }

--- a/src/add/iterable-operators/flatmap.ts
+++ b/src/add/iterable-operators/flatmap.ts
@@ -1,15 +1,15 @@
-import { IterableImpl } from '../../iterable';
+import { IterableX } from '../../iterable';
 import { flatMap } from '../../iterable/flatmap';
 
-function flatMapProto<TSource, TCollection, TResult>(this: IterableImpl<TSource>,
+function flatMapProto<TSource, TCollection, TResult>(this: IterableX<TSource>,
   fn: (value: TSource, index: number) => Iterable<TCollection>,
   resFn?: (value: TSource, current: TCollection) => TResult) {
   return flatMap(this, fn, resFn);
 };
-IterableImpl.prototype.flatMap = flatMapProto;
+IterableX.prototype.flatMap = flatMapProto;
 
 declare module '../../Iterable' {
-  interface IterableImpl<T> {
+  interface IterableX<T> {
     flatMap: typeof flatMapProto;
   }
 }

--- a/src/add/iterable-operators/map.ts
+++ b/src/add/iterable-operators/map.ts
@@ -1,14 +1,14 @@
-import { IterableImpl } from '../../iterable';
+import { IterableX } from '../../iterable';
 import { map } from '../../iterable/map';
 
- function mapProto<T, U>(this: IterableImpl<T>, fn: (value: T, index: number) => U, thisArg?: any): IterableImpl<U> {
+ function mapProto<T, U>(this: IterableX<T>, fn: (value: T, index: number) => U, thisArg?: any): IterableX<U> {
   return map(this, fn, thisArg);
 };
 
-IterableImpl.prototype.map = mapProto;
+IterableX.prototype.map = mapProto;
 
 declare module '../../Iterable' {
-  interface IterableImpl<T> {
+  interface IterableX<T> {
     map: typeof mapProto;
   }
 }

--- a/src/add/iterable/case.ts
+++ b/src/add/iterable/case.ts
@@ -1,4 +1,4 @@
-import { IterableImpl } from '../../iterable';
+import { IterableX } from '../../iterable';
 import { _case } from '../../iterable/case';
 
-IterableImpl.case = _case;
+IterableX.case = _case;

--- a/src/add/iterable/catchall.ts
+++ b/src/add/iterable/catchall.ts
@@ -1,10 +1,10 @@
-import { IterableImpl } from '../../iterable';
+import { IterableX } from '../../iterable';
 import { catchAllStatic } from '../../iterable/catchall';
 
-IterableImpl.catchAll = catchAllStatic;
+IterableX.catchAll = catchAllStatic;
 
 declare module '../../Iterable' {
-  namespace IterableImpl {
+  namespace IterableX {
     export let catchAll: typeof catchAllStatic;
   }
 }

--- a/src/add/iterable/concat.ts
+++ b/src/add/iterable/concat.ts
@@ -1,10 +1,10 @@
-import { IterableImpl } from '../../iterable';
+import { IterableX } from '../../iterable';
 import { concatStatic } from '../../iterable/concat';
 
-IterableImpl.concat = concatStatic;
+IterableX.concat = concatStatic;
 
 declare module '../../Iterable' {
-  namespace IterableImpl {
+  namespace IterableX {
     export let concat: typeof concatStatic;
   }
 }

--- a/src/add/iterable/create.ts
+++ b/src/add/iterable/create.ts
@@ -1,10 +1,10 @@
-import { IterableImpl } from '../../iterable';
+import { IterableX } from '../../iterable';
 import { create as createStatic } from '../../iterable/create';
 
-IterableImpl.create = createStatic;
+IterableX.create = createStatic;
 
 declare module '../../Iterable' {
-  namespace IterableImpl {
+  namespace IterableX {
     export let create: typeof createStatic;
   }
 }

--- a/src/add/iterable/deter.ts
+++ b/src/add/iterable/deter.ts
@@ -1,10 +1,10 @@
-import { IterableImpl } from '../../iterable';
+import { IterableX } from '../../iterable';
 import { defer as deferStatic } from '../../iterable/defer';
 
-IterableImpl.defer = deferStatic;
+IterableX.defer = deferStatic;
 
 declare module '../../Iterable' {
-  namespace IterableImpl {
+  namespace IterableX {
     export let defer: typeof deferStatic;
   }
 }

--- a/src/add/iterable/empty.ts
+++ b/src/add/iterable/empty.ts
@@ -1,10 +1,10 @@
-import { IterableImpl } from '../../iterable';
+import { IterableX } from '../../iterable';
 import { empty as emptyStatic } from '../../iterable/empty';
 
-IterableImpl.empty = emptyStatic;
+IterableX.empty = emptyStatic;
 
 declare module '../../Iterable' {
-  namespace IterableImpl {
+  namespace IterableX {
     export let empty: typeof emptyStatic;
   }
 }

--- a/src/add/iterable/from.ts
+++ b/src/add/iterable/from.ts
@@ -1,10 +1,10 @@
-import { IterableImpl } from '../../iterable';
+import { IterableX } from '../../iterable';
 import { from as fromStatic } from '../../iterable/from';
 
-IterableImpl.from = fromStatic;
+IterableX.from = fromStatic;
 
 declare module '../../Iterable' {
-  namespace IterableImpl {
+  namespace IterableX {
     export let from: typeof fromStatic;
   }
 }

--- a/src/add/iterable/if.ts
+++ b/src/add/iterable/if.ts
@@ -1,4 +1,4 @@
-import { IterableImpl } from '../../iterable';
+import { IterableX } from '../../iterable';
 import { _if } from '../../iterable/if';
 
-IterableImpl.if = _if;
+IterableX.if = _if;

--- a/src/add/iterable/onerrorresumenext.ts
+++ b/src/add/iterable/onerrorresumenext.ts
@@ -1,10 +1,10 @@
-import { IterableImpl } from '../../iterable';
+import { IterableX } from '../../iterable';
 import { onErrorResumeNextStatic } from '../../iterable/onerrorresumenext';
 
-IterableImpl.onErrorResumeNext = onErrorResumeNextStatic;
+IterableX.onErrorResumeNext = onErrorResumeNextStatic;
 
 declare module '../../Iterable' {
-  namespace IterableImpl {
+  namespace IterableX {
     export let onErrorResumeNext: typeof onErrorResumeNextStatic;
   }
 }

--- a/src/add/iterable/repeat.ts
+++ b/src/add/iterable/repeat.ts
@@ -1,10 +1,10 @@
-import { IterableImpl } from '../../iterable';
+import { IterableX } from '../../iterable';
 import { repeat as repeatStatic } from '../../iterable/repeat';
 
-IterableImpl.repeat = repeatStatic;
+IterableX.repeat = repeatStatic;
 
 declare module '../../Iterable' {
-  namespace IterableImpl {
+  namespace IterableX {
     export let repeat: typeof repeatStatic;
   }
 }

--- a/src/add/iterable/zip.ts
+++ b/src/add/iterable/zip.ts
@@ -1,10 +1,10 @@
-import { IterableImpl } from '../../iterable';
+import { IterableX } from '../../iterable';
 import { zipStatic } from '../../iterable/zip';
 
-IterableImpl.zip = zipStatic;
+IterableX.zip = zipStatic;
 
 declare module '../../Iterable' {
-  namespace IterableImpl {
+  namespace IterableX {
     export let zip: typeof zipStatic;
   }
 }

--- a/src/asynciterable.ts
+++ b/src/asynciterable.ts
@@ -2,7 +2,7 @@
 
 import { bindCallback } from './internal/bindcallback';
 
-export abstract class AsyncIterableImpl<T> {
+export abstract class AsyncIterableX<T> {
   abstract [Symbol.asyncIterator](): AsyncIterable<T>;
 
   async forEach(fn: (value: T, index: number) => void, thisArg?: any): Promise<void> {

--- a/src/asynciterable/from.ts
+++ b/src/asynciterable/from.ts
@@ -1,12 +1,12 @@
 'use strict';
 
-import { AsyncIterableImpl } from '../asynciterable';
-import { AsyncIteratorImpl } from '../asynciterator';
+import { AsyncIterableX } from '../asynciterable';
+import { AsyncIteratorX } from '../asynciterator';
 import { bindCallback } from '../internal/bindcallback';
 import { toLength } from '../internal/tolength';
 import { isIterable } from '../internal/isiterable';
 
-export class AsyncFromIterator<TSource, TResult> extends AsyncIteratorImpl<TResult> {
+export class AsyncFromIterator<TSource, TResult> extends AsyncIteratorX<TResult> {
   private _source: Iterable<TSource> | ArrayLike<TSource>;
   private _it: Iterator<TSource>;
   private _isIterable: boolean;
@@ -58,7 +58,7 @@ export class AsyncFromIterator<TSource, TResult> extends AsyncIteratorImpl<TResu
   }
 }
 
-export class AsyncFromIterable<TSource, TResult> extends AsyncIterableImpl<TResult> {
+export class AsyncFromIterable<TSource, TResult> extends AsyncIterableX<TResult> {
   private _source: Iterable<TSource> | Iterable<TSource> | ArrayLike<TSource>;
   private _fn?: (value: TSource, index: number) => TResult;
   private _thisArg: any;

--- a/src/asynciterable/map.ts
+++ b/src/asynciterable/map.ts
@@ -1,10 +1,10 @@
 'use strict';
 
-import { AsyncIterableImpl } from '../asynciterable';
-import { AsyncIteratorImpl } from '../asynciterator';
+import { AsyncIterableX } from '../asynciterable';
+import { AsyncIteratorX } from '../asynciterator';
 import { bindCallback } from '../internal/bindcallback';
 
-export class AsyncMapIterator<TSource, TResult> extends AsyncIteratorImpl<TResult> {
+export class AsyncMapIterator<TSource, TResult> extends AsyncIteratorX<TResult> {
   private _it: AsyncIterator<TSource>;
   private _fn: (value: TSource, index: number) => TResult;
   private _i: number;

--- a/src/asynciterator.ts
+++ b/src/asynciterator.ts
@@ -7,7 +7,7 @@ interface AsyncIteratorQueueItem {
   reject:  (reason: any) => void;
 }
 
-export abstract class AsyncIteratorImpl<T> implements AsyncIterator<T> {
+export abstract class AsyncIteratorX<T> implements AsyncIterator<T> {
   private _queue : Array<AsyncIteratorQueueItem>;
   private _current: AsyncIteratorQueueItem | undefined;
 

--- a/src/iterable.ts
+++ b/src/iterable.ts
@@ -3,7 +3,7 @@
 import { bindCallback } from './internal/bindcallback';
 
 
-export abstract class IterableImpl<T> implements Iterable<T> {
+export abstract class IterableX<T> implements Iterable<T> {
   abstract [Symbol.iterator](): Iterator<T>;
 
   forEach(fn: (value: T, index: number) => void, thisArg?: any): void {

--- a/src/iterable/arrayiterable.ts
+++ b/src/iterable/arrayiterable.ts
@@ -1,9 +1,9 @@
 'use strict';
 
-import { IterableImpl } from '../iterable';
-import { IteratorImpl } from '../iterator';
+import { IterableX } from '../iterable';
+import { IteratorX } from '../iterator';
 
-export class ArrayIterator<T> extends IteratorImpl<T> {
+export class ArrayIterator<T> extends IteratorX<T> {
   private _len: number;
   private _index: number;
 
@@ -20,7 +20,7 @@ export class ArrayIterator<T> extends IteratorImpl<T> {
   }
 }
 
-export class ArrayIterable<T> extends IterableImpl<T> {
+export class ArrayIterable<T> extends IterableX<T> {
   private _source: T[];
 
   constructor(source: T[]) {

--- a/src/iterable/buffer.ts
+++ b/src/iterable/buffer.ts
@@ -1,10 +1,10 @@
 'use strict';
 
 
-import { IterableImpl } from '../iterable';
-import { IteratorImpl } from '../iterator';
+import { IterableX } from '../iterable';
+import { IteratorX } from '../iterator';
 
-export class BufferIterator<T> extends IteratorImpl<T[]> {
+export class BufferIterator<T> extends IteratorX<T[]> {
   private _q: T[][];
   private _i: number;
   private _hasValue: boolean;
@@ -32,7 +32,7 @@ export class BufferIterator<T> extends IteratorImpl<T[]> {
   }
 }
 
-export class BufferIterable<T> extends IterableImpl<T[]> {
+export class BufferIterable<T> extends IterableX<T[]> {
   constructor(private _source: Iterable<T>, private _count: number, private _skip = _count) {
     super();
   }
@@ -42,6 +42,6 @@ export class BufferIterable<T> extends IterableImpl<T[]> {
   }
 }
 
-export function buffer<T>(source: Iterable<T>, count: number, skip?: number): IterableImpl<T[]> {
+export function buffer<T>(source: Iterable<T>, count: number, skip?: number): IterableX<T[]> {
   return new BufferIterable(source, count, skip);
 }

--- a/src/iterable/catch.ts
+++ b/src/iterable/catch.ts
@@ -1,10 +1,10 @@
 'use strict';
 
 
-import { IterableImpl } from '../iterable';
-import { IteratorImpl } from '../iterator';
+import { IterableX } from '../iterable';
+import { IteratorX } from '../iterator';
 
-export class CatchIterator<T> extends IteratorImpl<T> {
+export class CatchIterator<T> extends IteratorX<T> {
   constructor(private _it: Iterable<T>, private _fn: (error: any) => Iterable<T>) {
     super();
   }
@@ -18,7 +18,7 @@ export class CatchIterator<T> extends IteratorImpl<T> {
   }
 }
 
-export class CatchIterable<T> extends IterableImpl<T> {
+export class CatchIterable<T> extends IterableX<T> {
   constructor(private _source: Iterable<T>, private _fn: (error: any) => Iterable<T>) {
     super();
   }

--- a/src/iterable/catchall.ts
+++ b/src/iterable/catchall.ts
@@ -1,11 +1,11 @@
 'use strict';
 
 
-import { IterableImpl } from '../iterable';
-import { IteratorImpl } from '../iterator';
+import { IterableX } from '../iterable';
+import { IteratorX } from '../iterator';
 import { ArrayIterable } from './arrayiterable';
 
-export class CatchAllIterator<T> extends IteratorImpl<T> {
+export class CatchAllIterator<T> extends IteratorX<T> {
   private _it: ArrayIterable<Iterable<T>>;
   private _error: any;
   private _hasError: boolean;
@@ -33,7 +33,7 @@ export class CatchAllIterator<T> extends IteratorImpl<T> {
   }
 }
 
-export class CatchAllIterable<T> extends IterableImpl<T> {
+export class CatchAllIterable<T> extends IterableX<T> {
   private _source: Iterable<T>[];
 
   constructor(...source: Iterable<T>[]) {

--- a/src/iterable/concat.ts
+++ b/src/iterable/concat.ts
@@ -1,11 +1,11 @@
 'use strict';
 
 
-import { IterableImpl } from '../iterable';
-import { IteratorImpl } from '../iterator';
+import { IterableX } from '../iterable';
+import { IteratorX } from '../iterator';
 import { ArrayIterable } from './arrayiterable';
 
-export class ConcatIterator<T> extends IteratorImpl<T> {
+export class ConcatIterator<T> extends IteratorX<T> {
   private _it: Iterable<Iterable<T>>;
   constructor(...it: Iterable<T>[]) {
     super();
@@ -19,7 +19,7 @@ export class ConcatIterator<T> extends IteratorImpl<T> {
   }
 }
 
-export class ConcatIterable<T> extends IterableImpl<T> {
+export class ConcatIterable<T> extends IterableX<T> {
   private _source: Iterable<T>[];
 
   constructor(...source: Iterable<T>[]) {

--- a/src/iterable/concatall.ts
+++ b/src/iterable/concatall.ts
@@ -1,10 +1,10 @@
 'use strict';
 
 
-import { IterableImpl } from '../iterable';
-import { IteratorImpl } from '../iterator';
+import { IterableX } from '../iterable';
+import { IteratorX } from '../iterator';
 
-export class ConcatAllIterator<T> extends IteratorImpl<T> {
+export class ConcatAllIterator<T> extends IteratorX<T> {
   constructor(private _it: Iterable<Iterable<T>>) {
     super();
   }
@@ -16,7 +16,7 @@ export class ConcatAllIterator<T> extends IteratorImpl<T> {
   }
 }
 
-export class ConcatAllIterable<T> extends IterableImpl<T> {
+export class ConcatAllIterable<T> extends IterableX<T> {
   private _source: Iterable<Iterable<T>>;
 
   constructor(source: Iterable<Iterable<T>>) {

--- a/src/iterable/create.ts
+++ b/src/iterable/create.ts
@@ -1,9 +1,9 @@
 'use strict';
 
 
-import { IterableImpl } from '../iterable';
+import { IterableX } from '../iterable';
 
-class AnonymousIterable<T> extends IterableImpl<T> {
+class AnonymousIterable<T> extends IterableX<T> {
   private _fn: () => Iterator<T>;
 
   constructor(fn: () => Iterator<T>) {

--- a/src/iterable/defaultifempty.ts
+++ b/src/iterable/defaultifempty.ts
@@ -1,10 +1,10 @@
 'use strict';
 
 
-import { IterableImpl } from '../iterable';
-import { IteratorImpl } from '../iterator';
+import { IterableX } from '../iterable';
+import { IteratorX } from '../iterator';
 
-export class DefaultIfEmptyIterator<T> extends IteratorImpl<T> {
+export class DefaultIfEmptyIterator<T> extends IteratorX<T> {
   private _defaultValue: T;
   private _state: number;
 
@@ -25,7 +25,7 @@ export class DefaultIfEmptyIterator<T> extends IteratorImpl<T> {
   }
 }
 
-export class DefaultIfEmptyIterable<T> extends IterableImpl<T> {
+export class DefaultIfEmptyIterable<T> extends IterableX<T> {
   private _source: Iterable<T>;
   private _defaultValue: T;
 

--- a/src/iterable/defer.ts
+++ b/src/iterable/defer.ts
@@ -1,10 +1,10 @@
 'use strict';
 
 
-import { IterableImpl } from '../iterable';
-import { IteratorImpl } from '../iterator';
+import { IterableX } from '../iterable';
+import { IteratorX } from '../iterator';
 
-export class DeferIterator<T> extends IteratorImpl<T> {
+export class DeferIterator<T> extends IteratorX<T> {
   private _fn: () => Iterable<T>;
 
   constructor(fn: () => Iterable<T>) {
@@ -17,7 +17,7 @@ export class DeferIterator<T> extends IteratorImpl<T> {
   }
 }
 
-export class DeferIterable<T> extends IterableImpl<T> {
+export class DeferIterable<T> extends IterableX<T> {
   constructor(private _fn: () => Iterable<T>) {
     super();
   }

--- a/src/iterable/distinct.ts
+++ b/src/iterable/distinct.ts
@@ -2,11 +2,11 @@
 import { identity } from '../internal/identity';
 
 
-import { IterableImpl } from '../iterable';
-import { IteratorImpl } from '../iterator';
+import { IterableX } from '../iterable';
+import { IteratorX } from '../iterator';
 import { arrayIndexOf } from '../internal/arrayindexof';
 
-export class DistinctIterator<TSource, TKey> extends IteratorImpl<TSource> {
+export class DistinctIterator<TSource, TKey> extends IteratorX<TSource> {
   private _q: Array<TSource | TKey>;
 
   constructor(
@@ -28,7 +28,7 @@ export class DistinctIterator<TSource, TKey> extends IteratorImpl<TSource> {
   }
 }
 
-export class DistinctIterable<TSource, TKey> extends IterableImpl<TSource> {
+export class DistinctIterable<TSource, TKey> extends IterableX<TSource> {
   constructor(
     private _source: Iterable<TSource>,
     private _fn?: (value: TSource) => TKey,

--- a/src/iterable/distinctuntilchanged.ts
+++ b/src/iterable/distinctuntilchanged.ts
@@ -1,10 +1,10 @@
 'use strict';
 
 
-import { IterableImpl } from '../iterable';
-import { IteratorImpl } from '../iterator';
+import { IterableX } from '../iterable';
+import { IteratorX } from '../iterator';
 
-export class DistinctUntilChangedIterator<TSource, TKey> extends IteratorImpl<TSource> {
+export class DistinctUntilChangedIterator<TSource, TKey> extends IteratorX<TSource> {
   private _it: Iterator<TSource>;
   private _fn?: (value: TSource) => TKey;
   private _cmp: (x: TKey, y: TKey) => boolean;
@@ -36,7 +36,7 @@ export class DistinctUntilChangedIterator<TSource, TKey> extends IteratorImpl<TS
   }
 }
 
-export class DistinctUntilChangedIterable<TSource, TKey> extends IterableImpl<TSource> {
+export class DistinctUntilChangedIterable<TSource, TKey> extends IterableX<TSource> {
   private _source: Iterable<TSource>;
   private _fn: (value: TSource) => TKey;
   private _cmp: (x: TKey, y: TKey) => boolean;

--- a/src/iterable/empty.ts
+++ b/src/iterable/empty.ts
@@ -1,9 +1,9 @@
 'use strict';
 
-import { IterableImpl } from '../iterable';
-import { IteratorImpl } from '../iterator';
+import { IterableX } from '../iterable';
+import { IteratorX } from '../iterator';
 
-class EmptyIterator<T> extends IteratorImpl<T> {
+class EmptyIterator<T> extends IteratorX<T> {
   constructor() {
     super();
   }
@@ -13,7 +13,7 @@ class EmptyIterator<T> extends IteratorImpl<T> {
 
 const EMPTY_ITERATOR = new EmptyIterator<any>();
 
-export class EmptyIterable<T> extends IterableImpl<T> {
+export class EmptyIterable<T> extends IterableX<T> {
   constructor() {
     super();
   }

--- a/src/iterable/except.ts
+++ b/src/iterable/except.ts
@@ -1,11 +1,11 @@
 'use strict';
 
 
-import { IterableImpl } from '../iterable';
-import { IteratorImpl } from '../iterator';
+import { IterableX } from '../iterable';
+import { IteratorX } from '../iterator';
 import { arrayIndexOf } from '../internal/arrayindexof';
 
-export class ExceptIterator<T> extends IteratorImpl<T> {
+export class ExceptIterator<T> extends IteratorX<T> {
   private _second: Iterator<T>;
   private _map: T[];
   private _cmp: (x: T, y: T) => boolean;
@@ -37,7 +37,7 @@ export class ExceptIterator<T> extends IteratorImpl<T> {
   }
 }
 
-export class ExceptIterable<T> extends IterableImpl<T> {
+export class ExceptIterable<T> extends IterableX<T> {
   private _first: Iterable<T>;
   private _second: Iterable<T>;
   private _cmp: (x: T, y: T) => boolean;

--- a/src/iterable/expand.ts
+++ b/src/iterable/expand.ts
@@ -1,8 +1,8 @@
 
-import { IterableImpl } from '../iterable';
-import { IteratorImpl } from '../iterator';
+import { IterableX } from '../iterable';
+import { IteratorX } from '../iterator';
 
-export class ExpandIterator<T> extends IteratorImpl<T> {
+export class ExpandIterator<T> extends IteratorX<T> {
   private _q: Iterable<T>[];
   private _it: Iterator<T> | null;
   private _fn: (source: T) => Iterable<T>;
@@ -33,7 +33,7 @@ export class ExpandIterator<T> extends IteratorImpl<T> {
   }
 }
 
-export class ExpandIterable<T> extends IterableImpl<T> {
+export class ExpandIterable<T> extends IterableX<T> {
   private _source: Iterable<T>;
   private _fn: (source: T) => Iterable<T>
 

--- a/src/iterable/filter.ts
+++ b/src/iterable/filter.ts
@@ -1,11 +1,11 @@
 'use strict';
 
 
-import { IterableImpl } from '../iterable';
-import { IteratorImpl } from '../iterator';
+import { IterableX } from '../iterable';
+import { IteratorX } from '../iterator';
 import { bindCallback } from '../internal/bindcallback';
 
-export class FilterIterator<T> extends IteratorImpl<T> {
+export class FilterIterator<T> extends IteratorX<T> {
   private _fn: (value: T, index: number) => boolean;
   private _i: number;
 
@@ -24,7 +24,7 @@ export class FilterIterator<T> extends IteratorImpl<T> {
   }
 }
 
-export class FilterIterable<T> extends IterableImpl<T> {
+export class FilterIterable<T> extends IterableX<T> {
 
   constructor(private _source: Iterable<T>, private _fn: (value: T, index: number) => boolean, private _thisArg?: any) {
     super();

--- a/src/iterable/finally.ts
+++ b/src/iterable/finally.ts
@@ -1,10 +1,10 @@
 'use strict';
 
 
-import { IterableImpl } from '../iterable';
-import { IteratorImpl } from '../iterator';
+import { IterableX } from '../iterable';
+import { IteratorX } from '../iterator';
 
-export class FinallyIterator<T> extends IteratorImpl<T> {
+export class FinallyIterator<T> extends IteratorX<T> {
   private _it: Iterator<T>;
   private _fn: () => void;
   private _called: boolean;
@@ -33,7 +33,7 @@ export class FinallyIterator<T> extends IteratorImpl<T> {
   }
 }
 
-export class FinallyIterable<T> extends IterableImpl<T> {
+export class FinallyIterable<T> extends IterableX<T> {
   private _source: Iterable<T>;
   private _fn: () => void;
 

--- a/src/iterable/flatmap.ts
+++ b/src/iterable/flatmap.ts
@@ -2,10 +2,10 @@
 import { identity } from '../internal/identity';
 
 
-import { IterableImpl } from '../iterable';
-import { IteratorImpl } from '../iterator';
+import { IterableX } from '../iterable';
+import { IteratorX } from '../iterator';
 
-class FlatMapIterator<TSource, TCollection, TResult> extends IteratorImpl<TResult> {
+class FlatMapIterator<TSource, TCollection, TResult> extends IteratorX<TResult> {
   private _innerIt: Iterator<TCollection> | null;
   private _i: number;
 
@@ -28,7 +28,7 @@ class FlatMapIterator<TSource, TCollection, TResult> extends IteratorImpl<TResul
   }
 }
 
-export class FlatMapIterable<TSource, TCollection, TResult> extends IterableImpl<TResult> {
+export class FlatMapIterable<TSource, TCollection, TResult> extends IterableX<TResult> {
   private _source: Iterable<TSource>;
   private _fn: (value: TSource, index: number) => Iterable<TCollection>;
   private _resFn?: (value: TSource, current: TCollection) => TResult;

--- a/src/iterable/from.ts
+++ b/src/iterable/from.ts
@@ -1,15 +1,15 @@
 'use strict';
 
 
-import { IterableImpl } from '../iterable';
-import { IteratorImpl } from '../iterator';
+import { IterableX } from '../iterable';
+import { IteratorX } from '../iterator';
 import { bindCallback } from '../internal/bindcallback';
 import { toLength } from '../internal/tolength';
 import { isIterable } from '../internal/isiterable';
 
 const doneIterator = { done: true, value: undefined };
 
-class FromIterator<TSource, TResult> extends IteratorImpl<TResult> {
+class FromIterator<TSource, TResult> extends IteratorX<TResult> {
   private _source: Iterable<TSource> | ArrayLike<TSource>;
   private _it: Iterator<TSource>;
   private _isIterable: boolean;
@@ -54,7 +54,7 @@ class FromIterator<TSource, TResult> extends IteratorImpl<TResult> {
   }
 }
 
-export class FromIterable<TSource, TResult> extends IterableImpl<TResult> {
+export class FromIterable<TSource, TResult> extends IterableX<TResult> {
   private _source: Iterable<TSource> | ArrayLike<TSource>;
   private _fn?: (value: any, index: number) => any;
   private _thisArg: any;

--- a/src/iterable/generate.ts
+++ b/src/iterable/generate.ts
@@ -1,11 +1,11 @@
 'use strict';
 
-import { IterableImpl } from '../iterable';
-import { IteratorImpl } from '../iterator';
+import { IterableX } from '../iterable';
+import { IteratorX } from '../iterator';
 
 const doneIterator = { done: true, value: undefined };
 
-class GenerateIterator<TState, TResult> extends IteratorImpl<TResult> {
+class GenerateIterator<TState, TResult> extends IteratorX<TResult> {
   private _i: TState;
   private _condFn: (value: TState) => boolean;
   private _iterFn: (value: TState) => TState;
@@ -33,7 +33,7 @@ class GenerateIterator<TState, TResult> extends IteratorImpl<TResult> {
   }
 }
 
-class GenerateIterable<TState, TResult> extends IterableImpl<TResult> {
+class GenerateIterable<TState, TResult> extends IterableX<TResult> {
   private _i: TState;
   private _condFn: (value: TState) => boolean;
   private _iterFn: (value: TState) => TState;

--- a/src/iterable/ingoreelements.ts
+++ b/src/iterable/ingoreelements.ts
@@ -1,10 +1,10 @@
 'use strict';
 
 
-import { IterableImpl } from '../iterable';
-import { IteratorImpl } from '../iterator';
+import { IterableX } from '../iterable';
+import { IteratorX } from '../iterator';
 
-class IgnoreElementsIterator<T> extends IteratorImpl<T> {
+class IgnoreElementsIterator<T> extends IteratorX<T> {
   private _it: Iterator<T>;
 
   constructor(it: Iterator<T>) {
@@ -21,7 +21,7 @@ class IgnoreElementsIterator<T> extends IteratorImpl<T> {
   }
 }
 
-class IgnoreElementsIterable<T> extends IterableImpl<T> {
+class IgnoreElementsIterable<T> extends IterableX<T> {
   private _source: Iterable<T>;
 
   constructor(source: Iterable<T>) {

--- a/src/iterable/intersect.ts
+++ b/src/iterable/intersect.ts
@@ -1,8 +1,8 @@
 'use strict';
 
 
-import { IterableImpl } from '../iterable';
-import { IteratorImpl } from '../iterator';
+import { IterableX } from '../iterable';
+import { IteratorX } from '../iterator';
 import { arrayIndexOf } from '../internal/arrayindexof';
 
 function arrayRemove<T>(array: T[], item: T, comparer: (x: T, y: T) => boolean): boolean {
@@ -12,7 +12,7 @@ function arrayRemove<T>(array: T[], item: T, comparer: (x: T, y: T) => boolean):
   return true;
 }
 
-export class IntersectIterator<T> extends IteratorImpl<T> {
+export class IntersectIterator<T> extends IteratorX<T> {
   private _second: Iterator<T>;
   private _map: T[];
   private _cmp: (x: T, y: T) => boolean;
@@ -44,7 +44,7 @@ export class IntersectIterator<T> extends IteratorImpl<T> {
   }
 }
 
-export class IntersectIterable<T> extends IterableImpl<T> {
+export class IntersectIterable<T> extends IterableX<T> {
   private _first: Iterable<T>;
   private _second: Iterable<T>;
   private _cmp?: (x: T, y: T) => boolean;

--- a/src/iterable/map.ts
+++ b/src/iterable/map.ts
@@ -1,11 +1,11 @@
 'use strict';
 
 
-import { IterableImpl } from '../iterable';
-import { IteratorImpl } from '../iterator';
+import { IterableX } from '../iterable';
+import { IteratorX } from '../iterator';
 import { bindCallback } from '../internal/bindcallback';
 
-export class MapIterator<TSource, TResult> extends IteratorImpl<TResult> {
+export class MapIterator<TSource, TResult> extends IteratorX<TResult> {
   private _fn: (value: TSource, index: number) => TResult;
   private _i: number;
 
@@ -25,7 +25,7 @@ export class MapIterator<TSource, TResult> extends IteratorImpl<TResult> {
   }
 }
 
-export class MapIterable<TSource, TResult> extends IterableImpl<TResult> {
+export class MapIterable<TSource, TResult> extends IterableX<TResult> {
   private _source: Iterable<TSource>;
   private _fn: (value: TSource, index: number) => TResult;
   private _thisArg: any;
@@ -57,7 +57,7 @@ export class MapIterable<TSource, TResult> extends IterableImpl<TResult> {
 export function map<TSource, TResult>(
     source: Iterable<TSource>,
     fn: (value: TSource, index: number) => TResult,
-    thisArg?: any): IterableImpl<TResult> {
+    thisArg?: any): IterableX<TResult> {
   return source instanceof MapIterable ?
     source.internalMap(fn, thisArg) :
     new MapIterable(source, fn, thisArg);

--- a/src/iterable/onerrorresumenext.ts
+++ b/src/iterable/onerrorresumenext.ts
@@ -1,11 +1,11 @@
 'use strict';
 
 
-import { IterableImpl } from '../iterable';
-import { IteratorImpl } from '../iterator';
+import { IterableX } from '../iterable';
+import { IteratorX } from '../iterator';
 import { ArrayIterator } from './arrayiterable';
 
-export class OnErrorResumeNextIterator<T> extends IteratorImpl<T> {
+export class OnErrorResumeNextIterator<T> extends IteratorX<T> {
   private _it: Iterator<Iterator<T>>;
   private _innerIt: Iterator<T> | null;
 
@@ -42,7 +42,7 @@ export class OnErrorResumeNextIterator<T> extends IteratorImpl<T> {
   }
 }
 
-export class OnErrorResumeNextIterable<T> extends IterableImpl<T> {
+export class OnErrorResumeNextIterable<T> extends IterableX<T> {
   private _source: Iterable<T>[];
 
   constructor(...source: Iterable<T>[]) {

--- a/src/iterable/range.ts
+++ b/src/iterable/range.ts
@@ -1,10 +1,10 @@
 'use strict';
 
 
-import { IterableImpl } from '../iterable';
-import { IteratorImpl } from '../iterator';
+import { IterableX } from '../iterable';
+import { IteratorX } from '../iterator';
 
-class RangeIterator extends IteratorImpl<number> {
+class RangeIterator extends IteratorX<number> {
   private _current: number;
   private _end: number;
 
@@ -21,7 +21,7 @@ class RangeIterator extends IteratorImpl<number> {
   }
 }
 
-export class RangeIterable extends IterableImpl<number> {
+export class RangeIterable extends IterableX<number> {
   private _start: number;
   private _count: number;
 

--- a/src/iterable/repeat.ts
+++ b/src/iterable/repeat.ts
@@ -1,11 +1,11 @@
 'use strict';
 
-import { IterableImpl } from '../iterable';
-import { IteratorImpl } from '../iterator';
+import { IterableX } from '../iterable';
+import { IteratorX } from '../iterator';
 
 const doneIterator = { done: true, value: undefined };
 
-class RepeatIterator<T> extends IteratorImpl<T> {
+class RepeatIterator<T> extends IteratorX<T> {
   private _value: T;
   private _count: number;
   private _hasCount: boolean;
@@ -27,7 +27,7 @@ class RepeatIterator<T> extends IteratorImpl<T> {
   }
 }
 
-export class RepeatIterable<T> extends IterableImpl<T> {
+export class RepeatIterable<T> extends IterableX<T> {
   private _value: T;
   private _count: number;
 

--- a/src/iterable/retry.ts
+++ b/src/iterable/retry.ts
@@ -1,10 +1,10 @@
 'use strict';
 
 
-import { IterableImpl } from '../iterable';
-import { IteratorImpl } from '../iterator';
+import { IterableX } from '../iterable';
+import { IteratorX } from '../iterator';
 
-export class RetryIterator<T> extends IteratorImpl<T> {
+export class RetryIterator<T> extends IteratorX<T> {
   private _source: Iterable<T>;
   private _it: Iterator<T> | null;
   private _count?: number;
@@ -34,7 +34,7 @@ export class RetryIterator<T> extends IteratorImpl<T> {
   }
 }
 
-export class RetryIterable<T> extends IterableImpl<T> {
+export class RetryIterable<T> extends IterableX<T> {
   private _source: Iterable<T>;
   private _count: number;
 

--- a/src/iterable/scan.ts
+++ b/src/iterable/scan.ts
@@ -1,10 +1,10 @@
 'use strict';
 
 
-import { IterableImpl } from '../iterable';
-import { IteratorImpl } from '../iterator';
+import { IterableX } from '../iterable';
+import { IteratorX } from '../iterator';
 
-export class ScanIterator<TAccumulate, TSource> extends IteratorImpl<TAccumulate | TSource> {
+export class ScanIterator<TAccumulate, TSource> extends IteratorX<TAccumulate | TSource> {
   private _it: Iterator<TSource>;
   private _fn: (acc: TAccumulate | TSource, x: TSource, index: number) => TAccumulate;
   private _hs: boolean;
@@ -36,7 +36,7 @@ export class ScanIterator<TAccumulate, TSource> extends IteratorImpl<TAccumulate
   }
 }
 
-export class ScanIterable<TAccumulate, TSource> extends IterableImpl<TAccumulate | TSource> {
+export class ScanIterable<TAccumulate, TSource> extends IterableX<TAccumulate | TSource> {
   private _source: Iterable<TSource>;
   private _fn: (acc: TAccumulate | TSource, x: TSource, index: number) => TAccumulate;
   private _v: any;

--- a/src/iterable/share.ts
+++ b/src/iterable/share.ts
@@ -1,11 +1,11 @@
 'use strict';
 
 
-import { IterableImpl } from '../iterable';
-import { IteratorImpl } from '../iterator';
+import { IterableX } from '../iterable';
+import { IteratorX } from '../iterator';
 import { create } from './create';
 
-class SharedIterable<T> extends IterableImpl<T> {
+class SharedIterable<T> extends IterableX<T> {
   private _it: Iterator<T>;
 
   constructor(it: Iterator<T>) {

--- a/src/iterable/skip.ts
+++ b/src/iterable/skip.ts
@@ -1,10 +1,10 @@
 'use strict';
 
 
-import { IterableImpl } from '../iterable';
-import { IteratorImpl } from '../iterator';
+import { IterableX } from '../iterable';
+import { IteratorX } from '../iterator';
 
-export class SkipIterator<T> extends IteratorImpl<T> {
+export class SkipIterator<T> extends IteratorX<T> {
   private _it: Iterator<T>;
   private _count: number;
   private _skipped: boolean;
@@ -36,7 +36,7 @@ export class SkipIterator<T> extends IteratorImpl<T> {
   }
 }
 
-export class SkipIterable<T> extends IterableImpl<T> {
+export class SkipIterable<T> extends IterableX<T> {
   private _source: Iterable<T>;
   private _count: number;
 

--- a/src/iterable/skiplast.ts
+++ b/src/iterable/skiplast.ts
@@ -1,10 +1,10 @@
 'use strict';
 
 
-import { IterableImpl } from '../iterable';
-import { IteratorImpl } from '../iterator';
+import { IterableX } from '../iterable';
+import { IteratorX } from '../iterator';
 
-export class SkipLastIterator<T> extends IteratorImpl<T> {
+export class SkipLastIterator<T> extends IteratorX<T> {
   private _it: Iterator<T>;
   private _q: T[];
   private _count: number;
@@ -33,7 +33,7 @@ export class SkipLastIterator<T> extends IteratorImpl<T> {
   }
 }
 
-export class SkipLastIterable<T> extends IterableImpl<T> {
+export class SkipLastIterable<T> extends IterableX<T> {
   private _source: Iterable<T>;
   private _count: number;
 

--- a/src/iterable/skipwhile.ts
+++ b/src/iterable/skipwhile.ts
@@ -1,10 +1,10 @@
 'use strict';
 
 
-import { IterableImpl } from '../iterable';
-import { IteratorImpl } from '../iterator';
+import { IterableX } from '../iterable';
+import { IteratorX } from '../iterator';
 
-export class SkipWhileIterator<T> extends IteratorImpl<T> {
+export class SkipWhileIterator<T> extends IteratorX<T> {
   private _it: Iterator<T>;
   private _fn: (value: T, index: number) => boolean;
   private _i: number;
@@ -38,7 +38,7 @@ export class SkipWhileIterator<T> extends IteratorImpl<T> {
   }
 }
 
-export class SkipWhileIterable<T> extends IterableImpl<T> {
+export class SkipWhileIterable<T> extends IterableX<T> {
   private _source: Iterable<T>;
   private _fn: (value: T, index: number) => boolean;
 

--- a/src/iterable/take.ts
+++ b/src/iterable/take.ts
@@ -1,10 +1,10 @@
 'use strict';
 
 
-import { IterableImpl } from '../iterable';
-import { IteratorImpl } from '../iterator';
+import { IterableX } from '../iterable';
+import { IteratorX } from '../iterator';
 
-export class TakeIterator<T> extends IteratorImpl<T> {
+export class TakeIterator<T> extends IteratorX<T> {
   private _it: Iterator<T>;
   private _i: number;
 
@@ -27,7 +27,7 @@ export class TakeIterator<T> extends IteratorImpl<T> {
   }
 }
 
-export class TakeIterable<T> extends IterableImpl<T> {
+export class TakeIterable<T> extends IterableX<T> {
   private _source: Iterable<T>;
   private _count: number;
 

--- a/src/iterable/takelast.ts
+++ b/src/iterable/takelast.ts
@@ -1,10 +1,10 @@
 'use strict';
 
 
-import { IterableImpl } from '../iterable';
-import { IteratorImpl } from '../iterator';
+import { IterableX } from '../iterable';
+import { IteratorX } from '../iterator';
 
-export class TakeLastIterator<T> extends IteratorImpl<T> {
+export class TakeLastIterator<T> extends IteratorX<T> {
   private _it: Iterator<T>;
   private _count: number;
   private _q: T[];
@@ -35,7 +35,7 @@ export class TakeLastIterator<T> extends IteratorImpl<T> {
   }
 }
 
-export class TakeLastIterable<T> extends IterableImpl<T> {
+export class TakeLastIterable<T> extends IterableX<T> {
   private _source: Iterable<T>;
   private _count: number;
 

--- a/src/iterable/takewhile.ts
+++ b/src/iterable/takewhile.ts
@@ -1,10 +1,10 @@
 'use strict';
 
 
-import { IterableImpl } from '../iterable';
-import { IteratorImpl } from '../iterator';
+import { IterableX } from '../iterable';
+import { IteratorX } from '../iterator';
 
-export class TakeWhileIterator<T> extends IteratorImpl<T> {
+export class TakeWhileIterator<T> extends IteratorX<T> {
   private _it: Iterator<T>;
   private _fn: (value: T, index: number) => boolean;
   private _i: number;
@@ -28,7 +28,7 @@ export class TakeWhileIterator<T> extends IteratorImpl<T> {
   }
 }
 
-export class TakeWhileIterable<T> extends IterableImpl<T> {
+export class TakeWhileIterable<T> extends IterableX<T> {
   private _source: Iterable<T>;
   private _fn: (value: T, index: number) => boolean;
 

--- a/src/iterable/tap.ts
+++ b/src/iterable/tap.ts
@@ -1,10 +1,10 @@
 'use strict';
 
 
-import { IterableImpl } from '../iterable';
-import { IteratorImpl } from '../iterator';
+import { IterableX } from '../iterable';
+import { IteratorX } from '../iterator';
 
-export class TapIterator<T> extends IteratorImpl<T> {
+export class TapIterator<T> extends IteratorX<T> {
   private _it: Iterator<T>;
   private _obs: PartialObserver<T>;
   private _i: 0;
@@ -32,7 +32,7 @@ export class TapIterator<T> extends IteratorImpl<T> {
   }
 }
 
-export class TapIterable<T> extends IterableImpl<T> {
+export class TapIterable<T> extends IterableX<T> {
   private _source: Iterable<T>;
   private _obs: PartialObserver<T>;
 

--- a/src/iterable/union.ts
+++ b/src/iterable/union.ts
@@ -1,11 +1,11 @@
 'use strict';
 
 
-import { IterableImpl } from '../iterable';
-import { IteratorImpl } from '../iterator';
+import { IterableX } from '../iterable';
+import { IteratorX } from '../iterator';
 import { arrayIndexOf } from '../internal/arrayindexof';
 
-export class UnionIterator<T> extends IteratorImpl<T> {
+export class UnionIterator<T> extends IteratorX<T> {
   private _left: Iterator<T>;
   private _right: Iterator<T>;
   private _cmp: (x: T, y: T) => boolean;
@@ -55,7 +55,7 @@ export class UnionIterator<T> extends IteratorImpl<T> {
   }
 }
 
-export class UnionIterable<T> extends IterableImpl<T> {
+export class UnionIterable<T> extends IterableX<T> {
   private _left: Iterable<T>;
   private _right: Iterable<T>;
   private _cmp: (x: T, y: T) => boolean;

--- a/src/iterable/while.ts
+++ b/src/iterable/while.ts
@@ -1,11 +1,11 @@
 'use strict';
 
 
-import { IterableImpl } from '../iterable';
-import { IteratorImpl } from '../iterator';
+import { IterableX } from '../iterable';
+import { IteratorX } from '../iterator';
 import { ConcatAllIterable } from './concatall';
 
-class WhileIterator<T> extends IteratorImpl<Iterable<T>> {
+class WhileIterator<T> extends IteratorX<Iterable<T>> {
   private _source: Iterable<T>;
   private _fn: () => boolean;
 
@@ -24,7 +24,7 @@ class WhileIterator<T> extends IteratorImpl<Iterable<T>> {
   }
 }
 
-class WhileIterable<T> extends IterableImpl<Iterable<T>> {
+class WhileIterable<T> extends IterableX<Iterable<T>> {
   private _source: Iterable<T>;
   private _fn: () => boolean;
 

--- a/src/iterable/zip.ts
+++ b/src/iterable/zip.ts
@@ -1,11 +1,11 @@
 'use strict';
 
 
-import { IterableImpl } from '../iterable';
-import { IteratorImpl } from '../iterator';
+import { IterableX } from '../iterable';
+import { IteratorX } from '../iterator';
 import { MapIterable } from './map';
 
-export class ZipIterator<T> extends IteratorImpl<T> {
+export class ZipIterator<T> extends IteratorX<T> {
   private _it: Iterator<T>[];
 
   constructor(...it: Iterator<T>[]) {
@@ -24,7 +24,7 @@ export class ZipIterator<T> extends IteratorImpl<T> {
   }
 }
 
-export class ZipIterable<T> extends IterableImpl<T> {
+export class ZipIterable<T> extends IterableX<T> {
   private _source: Iterable<T>[];
 
   constructor(...source: Iterable<T>[]) {

--- a/src/iterator.ts
+++ b/src/iterator.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-export abstract class IteratorImpl<T> implements Iterator<T> {
+export abstract class IteratorX<T> implements Iterator<T> {
   protected abstract create(): Iterator<T>;
 
   private _iterator?: Iterator<T>;


### PR DESCRIPTION
This change is the one I proposed in https://github.com/ReactiveX/IxJS/pull/11#issuecomment-292788355

-------------------

@mattpodwysocki @david-driscoll how about this change? Or should I change to `IterableX`?