### PR TITLE
fix(typings): Fix IterableX#concatAll typings to accept IterableX<Iterable<T>>

### DIFF
--- a/src/add/iterable-operators/concatAll.ts
+++ b/src/add/iterable-operators/concatAll.ts
@@ -4,7 +4,7 @@ import { concatAll } from '../../iterable/concat';
 /**
  * @ignore
  */
-export function concatAllProto<T>(this: IterableX<IterableX<T>>): IterableX<T> {
+export function concatAllProto<T>(this: IterableX<Iterable<T>>): IterableX<T> {
   return concatAll(this);
 }
 


### PR DESCRIPTION
Looks like I typo'd this typing when I added the proto method definition.