### PR TITLE
fixing missing this in groupby operator prototype signatures

### DIFF
--- a/src/add/asynciterable-operators/groupby.ts
+++ b/src/add/asynciterable-operators/groupby.ts
@@ -3,20 +3,20 @@ import { groupBy, GroupedAsyncIterable } from '../../asynciterable/groupby';
 import { identityAsync } from '../../internal/identity';
 
 export function groupByProto<TSource, TKey>(
-    source: AsyncIterable<TSource>,
+    this: AsyncIterable<TSource>,
     keySelector: (value: TSource) => TKey | Promise<TKey>): AsyncIterableX<GroupedAsyncIterable<TKey, TSource>>;
 export function groupByProto<TSource, TKey, TValue>(
-    source: AsyncIterable<TSource>,
+    this: AsyncIterable<TSource>,
     keySelector: (value: TSource) => TKey | Promise<TKey>,
     elementSelector?: (value: TSource) => TValue | Promise<TValue>): AsyncIterableX<GroupedAsyncIterable<TKey, TValue>>;
 /**
  * @ignore
  */
 export function groupByProto<TSource, TKey, TValue>(
-    source: AsyncIterable<TSource>,
+    this: AsyncIterable<TSource>,
     keySelector: (value: TSource) => TKey | Promise<TKey>,
     elementSelector: (value: TSource) => TValue | Promise<TValue> = identityAsync): AsyncIterableX<GroupedAsyncIterable<TKey, TValue>> {
-  return groupBy<TSource, TKey, TValue>(source, keySelector, elementSelector);
+  return groupBy<TSource, TKey, TValue>(this, keySelector, elementSelector);
 }
 
 AsyncIterableX.prototype.groupBy = groupByProto;

--- a/src/add/iterable-operators/groupby.ts
+++ b/src/add/iterable-operators/groupby.ts
@@ -3,20 +3,20 @@ import { groupBy, GroupedIterable } from '../../iterable/groupby';
 import { identity } from '../../internal/identity';
 
 export function groupByProto<TSource, TKey>(
-  source: Iterable<TSource>,
+  this: Iterable<TSource>,
   keySelector: (value: TSource) => TKey): IterableX<GroupedIterable<TKey, TSource>>;
 export function groupByProto<TSource, TKey, TValue>(
-  source: Iterable<TSource>,
+  this: Iterable<TSource>,
   keySelector: (value: TSource) => TKey,
   elementSelector?: (value: TSource) => TValue): IterableX<GroupedIterable<TKey, TValue>>;
 /**
  * @ignore
  */
 export function groupByProto<TSource, TKey, TValue>(
-  source: Iterable<TSource>,
+  this: Iterable<TSource>,
   keySelector: (value: TSource) => TKey,
   elementSelector: (value: TSource) => TValue = identity): IterableX<GroupedIterable<TKey, TValue>> {
-  return groupBy<TSource, TKey, TValue>(source, keySelector, elementSelector);
+  return groupBy<TSource, TKey, TValue>(this, keySelector, elementSelector);
 }
 
 IterableX.prototype.groupBy = groupByProto;


### PR DESCRIPTION
replacing `source` param with `this` so that the outer iterable is properly composed in prototypal invocations.

<!--
Thank you very much for your pull request!
-->

**Description:**

**Related issue (if exists):**

resolves #33