### PR TITLE
adding resultselector parameter to groupby operators

### DIFF
--- a/spec/asynciterable-operators/groupby-spec.ts
+++ b/spec/asynciterable-operators/groupby-spec.ts
@@ -164,3 +164,46 @@ test('AsyncIterable#groupBy element selector', async t => {
 
   t.end();
 });
+
+test('AsyncIterable#groupBy result selector', async t => {
+  const xs = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+  const xss = from<number, number>(xs);
+  const ys = groupBy(xss, async x => x % 3, x => String.fromCharCode(97 + x), (k, v) => ({ k, v: from(v) }));
+
+  const it = ys[Symbol.asyncIterator]();
+
+  let next = await it.next();
+  t.false(next.done);
+  const g1 = next.value;
+  t.equal(g1.k, 0);
+  const g1it = g1.v[Symbol.asyncIterator]();
+  await hasNext(t, g1it, 'a');
+  await hasNext(t, g1it, 'd');
+  await hasNext(t, g1it, 'g');
+  await hasNext(t, g1it, 'j');
+  await noNext(t, g1it);
+
+  next = await it.next();
+  t.false(next.done);
+  const g2 = next.value;
+  t.equal(g2.k, 1);
+  const g2it = g2.v[Symbol.asyncIterator]();
+  await hasNext(t, g2it, 'b');
+  await hasNext(t, g2it, 'e');
+  await hasNext(t, g2it, 'h');
+  await noNext(t, g2it);
+
+  next = await it.next();
+  t.false(next.done);
+  const g3 = next.value;
+  t.equal(g3.k, 2);
+  const g3it = g3.v[Symbol.asyncIterator]();
+  await hasNext(t, g3it, 'c');
+  await hasNext(t, g3it, 'f');
+  await hasNext(t, g3it, 'i');
+  await noNext(t, g3it);
+
+  await noNext(t, it);
+
+  t.end();
+});

--- a/spec/iterable-operators/groupby-spec.ts
+++ b/spec/iterable-operators/groupby-spec.ts
@@ -155,3 +155,45 @@ test('Iterable#groupBy element selector', t => {
 
   t.end();
 });
+
+test('Iterable#groupBy result selector', t => {
+  const xs = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+  const ys = groupBy(xs, x => x % 3, x => String.fromCharCode(97 + x), (k, v) => ({ k, v }));
+
+  const it = ys[Symbol.iterator]();
+
+  let next = it.next();
+  t.false(next.done);
+  const g1 = next.value;
+  t.equal(g1.k, 0);
+  const g1it = g1.v[Symbol.iterator]();
+  hasNext(t, g1it, 'a');
+  hasNext(t, g1it, 'd');
+  hasNext(t, g1it, 'g');
+  hasNext(t, g1it, 'j');
+  noNext(t, g1it);
+
+  next = it.next();
+  t.false(next.done);
+  const g2 = next.value;
+  t.equal(g2.k, 1);
+  const g2it = g2.v[Symbol.iterator]();
+  hasNext(t, g2it, 'b');
+  hasNext(t, g2it, 'e');
+  hasNext(t, g2it, 'h');
+  noNext(t, g2it);
+
+  next = it.next();
+  t.false(next.done);
+  const g3 = next.value;
+  t.equal(g3.k, 2);
+  const g3it = g3.v[Symbol.iterator]();
+  hasNext(t, g3it, 'c');
+  hasNext(t, g3it, 'f');
+  hasNext(t, g3it, 'i');
+  noNext(t, g3it);
+
+  noNext(t, it);
+
+  t.end();
+});

--- a/src/add/asynciterable-operators/groupby.ts
+++ b/src/add/asynciterable-operators/groupby.ts
@@ -1,5 +1,5 @@
 import { AsyncIterableX } from '../../asynciterable';
-import { groupBy, GroupedAsyncIterable } from '../../asynciterable/groupby';
+import { groupBy, groupByResultIdentityAsync, GroupedAsyncIterable } from '../../asynciterable/groupby';
 import { identityAsync } from '../../internal/identity';
 
 export function groupByProto<TSource, TKey>(
@@ -9,14 +9,20 @@ export function groupByProto<TSource, TKey, TValue>(
     this: AsyncIterable<TSource>,
     keySelector: (value: TSource) => TKey | Promise<TKey>,
     elementSelector?: (value: TSource) => TValue | Promise<TValue>): AsyncIterableX<GroupedAsyncIterable<TKey, TValue>>;
+export function groupByProto<TSource, TKey, TValue, TResult>(
+    this: AsyncIterable<TSource>,
+    keySelector: (value: TSource) => TKey | Promise<TKey>,
+    elementSelector?: (value: TSource) => TValue | Promise<TValue>,
+    resultSelector?: (key: TKey, values: Iterable<TValue>) => TResult | Promise<TResult>): AsyncIterableX<TResult>;
 /**
  * @ignore
  */
-export function groupByProto<TSource, TKey, TValue>(
+export function groupByProto<TSource, TKey, TValue, TResult>(
     this: AsyncIterable<TSource>,
     keySelector: (value: TSource) => TKey | Promise<TKey>,
-    elementSelector: (value: TSource) => TValue | Promise<TValue> = identityAsync): AsyncIterableX<GroupedAsyncIterable<TKey, TValue>> {
-  return groupBy<TSource, TKey, TValue>(this, keySelector, elementSelector);
+    elementSelector: (value: TSource) => TValue | Promise<TValue> = identityAsync,
+    resultSelector: (key: TKey, values: Iterable<TValue>) => TResult | Promise<TResult> = groupByResultIdentityAsync): AsyncIterableX<TResult> {
+  return groupBy<TSource, TKey, TValue, TResult>(this, keySelector, elementSelector, resultSelector);
 }
 
 AsyncIterableX.prototype.groupBy = groupByProto;

--- a/src/add/iterable-operators/groupby.ts
+++ b/src/add/iterable-operators/groupby.ts
@@ -1,5 +1,5 @@
 import { IterableX } from '../../iterable';
-import { groupBy, GroupedIterable } from '../../iterable/groupby';
+import { groupBy, GroupedIterable, groupByResultIdentity } from '../../iterable/groupby';
 import { identity } from '../../internal/identity';
 
 export function groupByProto<TSource, TKey>(
@@ -9,14 +9,20 @@ export function groupByProto<TSource, TKey, TValue>(
   this: Iterable<TSource>,
   keySelector: (value: TSource) => TKey,
   elementSelector?: (value: TSource) => TValue): IterableX<GroupedIterable<TKey, TValue>>;
+export function groupByProto<TSource, TKey, TValue, TResult>(
+  this: Iterable<TSource>,
+  keySelector: (value: TSource) => TKey | Promise<TKey>,
+  elementSelector?: (value: TSource) => TValue | Promise<TValue>,
+  resultSelector?: (key: TKey, values: Iterable<TValue>) => TResult): IterableX<TResult>;
 /**
  * @ignore
  */
-export function groupByProto<TSource, TKey, TValue>(
+export function groupByProto<TSource, TKey, TValue, TResult>(
   this: Iterable<TSource>,
   keySelector: (value: TSource) => TKey,
-  elementSelector: (value: TSource) => TValue = identity): IterableX<GroupedIterable<TKey, TValue>> {
-  return groupBy<TSource, TKey, TValue>(this, keySelector, elementSelector);
+  elementSelector: (value: TSource) => TValue = identity,
+  resultSelector: (key: TKey, values: Iterable<TValue>) => TResult = groupByResultIdentity): IterableX<TResult> {
+  return groupBy<TSource, TKey, TValue, TResult>(this, keySelector, elementSelector, resultSelector);
 }
 
 IterableX.prototype.groupBy = groupByProto;

--- a/src/iterable/groupby.ts
+++ b/src/iterable/groupby.ts
@@ -17,39 +17,52 @@ export class GroupedIterable<TKey, TValue> extends IterableX<TValue> {
   }
 }
 
-export class GroupByIterable<TSource, TKey, TValue> extends IterableX<GroupedIterable<TKey, TValue>> {
+export class GroupByIterable<TSource, TKey, TValue, TResult> extends IterableX<TResult> {
   private _source: Iterable<TSource>;
   private _keySelector: (value: TSource) => TKey;
   private _elementSelector: (value: TSource) => TValue;
+  private _resultSelector: (key: TKey, values: Iterable<TValue>) => TResult;
 
   constructor(
       source: Iterable<TSource>,
       keySelector: (value: TSource) => TKey,
-      elementSelector: (value: TSource) => TValue) {
+      elementSelector: (value: TSource) => TValue,
+      resultSelector: (key: TKey, values: Iterable<TValue>) => TResult) {
     super();
     this._source = source;
     this._keySelector = keySelector;
     this._elementSelector = elementSelector;
+    this._resultSelector = resultSelector;
   }
 
   *[Symbol.iterator]() {
     const map = createGrouping(this._source, this._keySelector, this._elementSelector);
     for (let [key, values] of map) {
-      yield new GroupedIterable(key, values);
+      yield this._resultSelector(key, values);
     }
   }
 }
 
+export function groupByResultIdentity<TKey, TValue>(key: TKey, values: Iterable<TValue>): any {
+  return new GroupedIterable(key, values);
+}
+
 export function groupBy<TSource, TKey>(
-    source: Iterable<TSource>,
-    keySelector: (value: TSource) => TKey): IterableX<GroupedIterable<TKey, TSource>>;
+  source: Iterable<TSource>,
+  keySelector: (value: TSource) => TKey): IterableX<GroupedIterable<TKey, TSource>>;
 export function groupBy<TSource, TKey, TValue>(
   source: Iterable<TSource>,
   keySelector: (value: TSource) => TKey,
   elementSelector?: (value: TSource) => TValue): IterableX<GroupedIterable<TKey, TValue>>;
-export function groupBy<TSource, TKey, TValue>(
+export function groupBy<TSource, TKey, TValue, TResult>(
+  source: Iterable<TSource>,
+  keySelector: (value: TSource) => TKey,
+  elementSelector?: (value: TSource) => TValue,
+  resultSelector?: (key: TKey, values: Iterable<TValue>) => TResult): IterableX<TResult>;
+export function groupBy<TSource, TKey, TValue, TResult>(
     source: Iterable<TSource>,
     keySelector: (value: TSource) => TKey,
-    elementSelector: (value: TSource) => TValue = identity): IterableX<GroupedIterable<TKey, TValue>> {
-  return new GroupByIterable<TSource, TKey, TValue>(source, keySelector, elementSelector);
+    elementSelector: (value: TSource) => TValue = identity,
+    resultSelector: (key: TKey, values: Iterable<TValue>) => TResult = groupByResultIdentity): IterableX<TResult> {
+  return new GroupByIterable<TSource, TKey, TValue, TResult>(source, keySelector, elementSelector, resultSelector);
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!
-->

**Description:**
This PR adds a new parameter (`resultSelector`) to the end of the parameter list for both async and non-async `groupBy` operators. `resultSelector` allows the operator to project the results to a custom structure rather than using the default `GroupedIterable` or `GroupedAsyncIterable`. By default, if not specified, `resultSelector` simply uses the `groupByResultIdentity` or `groupByResultIdentityAsync` function for projection, which creates the `GroupedIterable` or `GroupedAsyncIterable` instance.

**Related issue (if exists):**
resolves #35 