### PR TITLE
some operator now supports parameterless calls

### DIFF
--- a/spec/asynciterable-operators/some-spec.ts
+++ b/spec/asynciterable-operators/some-spec.ts
@@ -18,6 +18,20 @@ test('AsyncIterable#some some false', async (t: test.Test) => {
   t.end();
 });
 
+test('AsyncIterable#some some parameterless empty', async (t: test.Test) => {
+  const xs = of();
+  const ys = await some(xs);
+  t.false(ys);
+  t.end();
+});
+
+test('AsyncIterable#some some parameterless non-empty', async (t: test.Test) => {
+  const xs = of(2, 4, 6, 8);
+  const ys = await some(xs);
+  t.true(ys);
+  t.end();
+});
+
 test('AsyncIterable#some throws', async (t: test.Test) => {
   const err = new Error();
   const xs = _throw<number>(err);

--- a/spec/iterable-operators/some-spec.ts
+++ b/spec/iterable-operators/some-spec.ts
@@ -13,3 +13,15 @@ test('Iterable#some none true', t => {
   t.false(res);
   t.end();
 });
+
+test('Iterable#some some parameterless empty', t => {
+  const res = some([]);
+  t.false(res);
+  t.end();
+});
+
+test('Iterable#some some parameterless non-empty', t => {
+  const res = some([1, 2, 3, 4]);
+  t.true(res);
+  t.end();
+});

--- a/src/add/asynciterable-operators/some.ts
+++ b/src/add/asynciterable-operators/some.ts
@@ -6,7 +6,7 @@ import { some } from '../../asynciterable/some';
  */
 export function someProto<T>(
     this: AsyncIterableX<T>,
-    comparer: (value: T, index: number) => boolean | Promise<boolean>): Promise<boolean> {
+    comparer?: (value: T, index: number) => boolean | Promise<boolean>): Promise<boolean> {
   return some(this, comparer);
 }
 

--- a/src/add/iterable-operators/some.ts
+++ b/src/add/iterable-operators/some.ts
@@ -6,7 +6,7 @@ import { some } from '../../iterable/some';
  */
 export function someProto<T>(
     this: IterableX<T>,
-    comparer: (value: T, index: number) => boolean): boolean {
+    comparer?: (value: T, index: number) => boolean): boolean {
   return some(this, comparer);
 }
 

--- a/src/asynciterable/some.ts
+++ b/src/asynciterable/some.ts
@@ -1,9 +1,9 @@
 export async function some<T>(
     source: AsyncIterable<T>,
-    comparer: (value: T, index: number) => boolean | Promise<boolean>): Promise<boolean> {
+    comparer?: (value: T, index: number) => boolean | Promise<boolean>): Promise<boolean> {
   let i = 0;
   for await (let item of source) {
-    if (await comparer(item, i++)) { return true; }
+    if (!comparer || await comparer(item, i++)) { return true; }
   }
   return false;
 }

--- a/src/iterable/some.ts
+++ b/src/iterable/some.ts
@@ -1,9 +1,9 @@
 export function some<T>(
     source: Iterable<T>,
-    comparer: (value: T, index: number) => boolean): boolean {
+    comparer?: (value: T, index: number) => boolean): boolean {
   let i = 0;
   for (let item of source) {
-    if (comparer(item, i++)) { return true; }
+    if (!comparer || comparer(item, i++)) { return true; }
   }
   return false;
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!
-->

**Description:**

the `comparer` parameter in the `some` operators is not strictly necessary as we can always assume its absence is equivalent to `() => true`.

**Related issue (if exists):**

resolves #29 