### PR TITLE
Fix mjs main

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ script:
     elif [ "$CI_MATRIX_LINT" = "true" ]; then
       npm run lint
     elif [ "$CI_MATRIX_TEST" = "true" ]; then
-      export IS_TRAVIS=true
       npm run build
       echo "sleeping 10s" && sleep 10
       npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,9 +37,7 @@ script:
     elif [ "$CI_MATRIX_LINT" = "true" ]; then
       npm run lint
     elif [ "$CI_MATRIX_TEST" = "true" ]; then
-      npm run build
-      echo "sleeping 10s" && sleep 10
-      npm test
+      npm run build && npm test
     else
       echo "This code path is run unexpectedly" 1>&2
       exit 1

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -331,10 +331,11 @@ const compileClosure = ((cache) => memoizeTask(cache, function closure(target, f
 const createIxPackageJson = (target, format) => (orig) => ({
   ...createTsPackageJson(target, format)(orig),
   name: orig.name,
-  main: `Ix.js`,
+  main: `Ix`,
   module: `Ix.mjs`,
-  browser: `Ix.min.js`,
-  [`@std/esm`]: { esm: `mjs` }
+  browser: `Ix.es5.min.js`,
+  [`@std/esm`]: { esm: `mjs` },
+  [`browser:es2015`]: `Ix.es2015.min.js`,
 });
 
 const createTsPackageJson = (target, format) => (orig) => ({
@@ -348,7 +349,8 @@ const createScopedPackage = (target, format) => (({ name, ...orig }) =>
       (xs, key) => ({ ...xs, [key]: xs[key] || orig[key] }),
       { name: `@reactivex/${name}-${_name(target, format)}`,
         version: undefined, main: `Ix.js`, types: `Ix.d.ts`,
-        module: undefined, browser: undefined, [`@std/esm`]: undefined }
+        browser: undefined, [`browser:es2015`]: undefined,
+        module: undefined, [`@std/esm`]: undefined }
     )
   )
 );

--- a/spec/Ix.ts
+++ b/spec/Ix.ts
@@ -2,7 +2,7 @@
 
 // Dynamically load an Ix target build based on environment vars
 
-const resolve = require('path').resolve;
+const path = require('path');
 const target = process.env.IX_TARGET || ``;
 const format = process.env.IX_MODULE || ``;
 
@@ -19,10 +19,10 @@ let modulePath = ``;
 if (target === `ts` || target === `ix`) modulePath = target;
 else if (!~targets.indexOf(target)) throwInvalidImportError('target', target, targets);
 else if (!~formats.indexOf(format)) throwInvalidImportError('module', format, formats);
-else modulePath = `${target}/${format}`;
+else modulePath = path.join(target, format);
 
-let Ix: any = require(resolve(`./targets/${modulePath}/Ix`));
-let IxInternal: any = require(resolve(`./targets/${modulePath}/Ix.internal`));
+let Ix: any = require(path.resolve(`./targets`, modulePath, `Ix`));
+let IxInternal: any = require(path.resolve(`./targets`, modulePath, `Ix.internal`));
 
 import { Iterable as Iterable_ } from '../src/Ix';
 import { AsyncSink as AsyncSink_ } from '../src/Ix';


### PR DESCRIPTION
By not specifying a file extension in package.json's "main" field, node will pick the right mjs or js entries based on whether it's running with `--experimental-modules` set or not.