### PR TITLE
feat(operators): support user defined type guards in boolean predicates

### DIFF
--- a/spec/asynciterable-operators/filter-spec.ts
+++ b/spec/asynciterable-operators/filter-spec.ts
@@ -34,6 +34,26 @@ test('AsyncIterable#filter with index', async t => {
   t.end();
 });
 
+test('AsyncIterable#filter with typeguard', async t => {
+  const xs = of<any>(
+    new String('8'), 5,
+    new String('7'), 4,
+    new String('6'), 9,
+    new String('2'), 1,
+    new String('0')
+  );
+  const ys = filter(xs, (x): x is string => x instanceof String);
+
+  const it = ys[Symbol.asyncIterator]();
+  await hasNext(t, it, new String('8'));
+  await hasNext(t, it, new String('7'));
+  await hasNext(t, it, new String('6'));
+  await hasNext(t, it, new String('2'));
+  await hasNext(t, it, new String('0'));
+  await noNext(t, it);
+  t.end();
+});
+
 test('AsyncIterable#filter throws part way through', async t => {
   const xs = of(8, 5, 7, 4, 6, 9, 2, 1, 0);
   const err = new Error();

--- a/spec/iterable-operators/filter-spec.ts
+++ b/spec/iterable-operators/filter-spec.ts
@@ -33,6 +33,26 @@ test('Iterable#filter with index', t => {
   t.end();
 });
 
+test('Iterable#filter with typeguard', t => {
+  const xs = [
+    new String('8'), 5,
+    new String('7'), 4,
+    new String('6'), 9,
+    new String('2'), 1,
+    new String('0')
+  ];
+  const ys = filter(xs, (x): x is string => x instanceof String);
+
+  const it = ys[Symbol.iterator]();
+  hasNext(t, it, new String('8'));
+  hasNext(t, it, new String('7'));
+  hasNext(t, it, new String('6'));
+  hasNext(t, it, new String('2'));
+  hasNext(t, it, new String('0'));
+  noNext(t, it);
+  t.end();
+});
+
 test('Iterable#filter throws part way through', t => {
   const xs = [8, 5, 7, 4, 6, 9, 2, 1, 0];
   const err = new Error();

--- a/spec/tape-async.d.ts
+++ b/spec/tape-async.d.ts
@@ -1,4 +1,4 @@
-declare module "tape-async" {
+declare module 'tape-async' {
     import * as tape from 'tape';
     export = tape;
 }

--- a/src/add/asynciterable-operators/every.ts
+++ b/src/add/asynciterable-operators/every.ts
@@ -1,12 +1,13 @@
 import { AsyncIterableX } from '../../asynciterable';
 import { every } from '../../asynciterable/every';
+import { booleanAsyncPredicate } from '../../internal/predicates';
 
 /**
  * @ignore
  */
 export function everyProto<T>(
     this: AsyncIterableX<T>,
-    comparer: (value: T, index: number) => boolean | Promise<boolean>): Promise<boolean> {
+    comparer: booleanAsyncPredicate<T>): Promise<boolean> {
   return every<T>(this, comparer);
 }
 

--- a/src/add/asynciterable-operators/filter.ts
+++ b/src/add/asynciterable-operators/filter.ts
@@ -1,12 +1,13 @@
 import { AsyncIterableX } from '../../asynciterable';
 import { filter } from '../../asynciterable/filter';
+import { booleanAsyncPredicate } from '../../internal/predicates';
 
 /**
  * @ignore
  */
 export function filterProto<TSource>(
     this: AsyncIterable<TSource>,
-    predicate: (value: TSource, index: number) => Promise<boolean> | boolean,
+    predicate: booleanAsyncPredicate<TSource>,
     thisArg?: any): AsyncIterableX<TSource> {
   return filter<TSource>(this, predicate, thisArg);
 }

--- a/src/add/asynciterable-operators/find.ts
+++ b/src/add/asynciterable-operators/find.ts
@@ -1,12 +1,13 @@
 import { AsyncIterableX } from '../../asynciterable';
 import { find } from '../../asynciterable/find';
+import { booleanAsyncPredicate } from '../../internal/predicates';
 
 /**
  * @ignore
  */
 export function findProto<T>(
     this: AsyncIterableX<T>,
-    predicate: (value: T, index: number) => boolean | Promise<boolean>,
+    predicate: booleanAsyncPredicate<T>,
     thisArg?: any): Promise<T | undefined> {
   return find(this, predicate, thisArg);
 }

--- a/src/add/asynciterable-operators/first.ts
+++ b/src/add/asynciterable-operators/first.ts
@@ -1,12 +1,13 @@
 import { AsyncIterableX } from '../../asynciterable';
 import { first } from '../../asynciterable/first';
+import { booleanAsyncPredicate } from '../../internal/predicates';
 
 /**
  * @ignore
  */
 export function firstProto<T>(
     this: AsyncIterableX<T>,
-    fn?: (value: T) => boolean | Promise<boolean>): Promise<T | undefined> {
+    fn?: booleanAsyncPredicate<T>): Promise<T | undefined> {
   return first(this, fn);
 }
 

--- a/src/add/asynciterable-operators/last.ts
+++ b/src/add/asynciterable-operators/last.ts
@@ -1,12 +1,13 @@
 import { AsyncIterableX } from '../../asynciterable';
 import { last } from '../../asynciterable/last';
+import { booleanAsyncPredicate } from '../../internal/predicates';
 
 /**
  * @ignore
  */
 export function lastProto<T>(
     this: AsyncIterableX<T>,
-    selector: (value: T) => boolean | Promise<boolean> = async () => true): Promise<T | undefined> {
+    selector?: booleanAsyncPredicate<T>): Promise<T | undefined> {
   return last(this, selector);
 }
 

--- a/src/add/asynciterable-operators/partition.ts
+++ b/src/add/asynciterable-operators/partition.ts
@@ -1,12 +1,13 @@
 import { AsyncIterableX } from '../../asynciterable';
 import { partition } from '../../asynciterable/partition';
+import { booleanAsyncPredicate } from '../../internal/predicates';
 
 /**
  * @ignore
  */
 export function partitionProto<T>(
     this: AsyncIterableX<T>,
-    fn: (value: T, index: number) => boolean,
+    fn: booleanAsyncPredicate<T>,
     thisArg?: any): AsyncIterableX<T>[] {
   return partition<T>(this, fn, thisArg);
 }

--- a/src/add/asynciterable-operators/single.ts
+++ b/src/add/asynciterable-operators/single.ts
@@ -1,12 +1,13 @@
 import { AsyncIterableX } from '../../asynciterable';
 import { single } from '../../asynciterable/single';
+import { booleanAsyncPredicate } from '../../internal/predicates';
 
 /**
  * @ignore
  */
 export function singleProto<T>(
     this: AsyncIterableX<T>,
-    selector: (value: T) => boolean | Promise<boolean> = async () => true): Promise<T | undefined> {
+    selector?: booleanAsyncPredicate<T>): Promise<T | undefined> {
   return single(this, selector);
 }
 

--- a/src/add/asynciterable-operators/skipwhile.ts
+++ b/src/add/asynciterable-operators/skipwhile.ts
@@ -1,12 +1,13 @@
 import { AsyncIterableX } from '../../asynciterable';
 import { skipWhile } from '../../asynciterable/skipwhile';
+import { booleanAsyncPredicate } from '../../internal/predicates';
 
 /**
  * @ignore
  */
 export function skipWhileProto<TSource>(
     this: AsyncIterableX<TSource>,
-    predicate: (value: TSource, index: number) => boolean | Promise<boolean>): AsyncIterableX<TSource> {
+    predicate: booleanAsyncPredicate<TSource>): AsyncIterableX<TSource> {
   return skipWhile(this, predicate);
 }
 

--- a/src/add/asynciterable-operators/some.ts
+++ b/src/add/asynciterable-operators/some.ts
@@ -1,12 +1,13 @@
 import { AsyncIterableX } from '../../asynciterable';
 import { some } from '../../asynciterable/some';
+import { booleanAsyncPredicate } from '../../internal/predicates';
 
 /**
  * @ignore
  */
 export function someProto<T>(
     this: AsyncIterableX<T>,
-    comparer: (value: T, index: number) => boolean | Promise<boolean>): Promise<boolean> {
+    comparer: booleanAsyncPredicate<T>): Promise<boolean> {
   return some(this, comparer);
 }
 

--- a/src/add/asynciterable-operators/takewhile.ts
+++ b/src/add/asynciterable-operators/takewhile.ts
@@ -1,12 +1,13 @@
 import { AsyncIterableX } from '../../asynciterable';
 import { takeWhile } from '../../asynciterable/takewhile';
+import { booleanAsyncPredicate } from '../../internal/predicates';
 
 /**
  * @ignore
  */
 export function takeWhileProto<TSource>(
     this: AsyncIterableX<TSource>,
-    predicate: (value: TSource, index: number) => boolean | Promise<boolean>): AsyncIterableX<TSource> {
+    predicate: booleanAsyncPredicate<TSource>): AsyncIterableX<TSource> {
   return takeWhile(this, predicate);
 }
 

--- a/src/asynciterable/every.ts
+++ b/src/asynciterable/every.ts
@@ -1,6 +1,8 @@
+import { booleanAsyncPredicate } from '../internal/predicates';
+
 export async function every<T>(
     source: AsyncIterable<T>,
-    comparer: (value: T, index: number) => boolean | Promise<boolean>): Promise<boolean> {
+    comparer: booleanAsyncPredicate<T>): Promise<boolean> {
   let i = 0;
   for await (let item of source) {
     if (!await comparer(item, i++)) { return false; }

--- a/src/asynciterable/filter.ts
+++ b/src/asynciterable/filter.ts
@@ -1,13 +1,14 @@
 import { AsyncIterableX } from '../asynciterable';
 import { bindCallback } from '../internal/bindcallback';
+import { booleanAsyncPredicate } from '../internal/predicates';
 
 class FilterAsyncIterable<TSource> extends AsyncIterableX<TSource> {
   private _source: Iterable<TSource | PromiseLike<TSource>> | AsyncIterable<TSource>;
-  private _predicate: (value: TSource, index: number) => Promise<boolean> | boolean;
+  private _predicate: booleanAsyncPredicate<TSource>;
 
   constructor(
     source: Iterable<TSource | PromiseLike<TSource>> | AsyncIterable<TSource>,
-    predicate: (value: TSource, index: number) => Promise<boolean> | boolean) {
+    predicate: booleanAsyncPredicate<TSource>) {
     super();
     this._source = source;
     this._predicate = predicate;
@@ -25,7 +26,7 @@ class FilterAsyncIterable<TSource> extends AsyncIterableX<TSource> {
 
 export function filter<TSource>(
     source: Iterable<TSource | PromiseLike<TSource>> | AsyncIterable<TSource>,
-    predicate: (value: TSource, index: number) => Promise<boolean> | boolean,
+    predicate: booleanAsyncPredicate<TSource>,
     thisArg?: any): AsyncIterableX<TSource> {
   return new FilterAsyncIterable<TSource>(source, bindCallback(predicate, thisArg, 2));
 }

--- a/src/asynciterable/find.ts
+++ b/src/asynciterable/find.ts
@@ -1,8 +1,9 @@
 import { bindCallback } from '../internal/bindcallback';
+import { booleanAsyncPredicate } from '../internal/predicates';
 
 export async function find<T>(
     source: AsyncIterable<T>,
-    predicate: (value: T, index: number) => boolean | Promise<boolean>,
+    predicate: booleanAsyncPredicate<T>,
     thisArg?: any): Promise<T | undefined> {
   const fn = bindCallback(predicate, thisArg, 2);
   let i = 0;

--- a/src/asynciterable/first.ts
+++ b/src/asynciterable/first.ts
@@ -1,8 +1,11 @@
+import { booleanAsyncPredicate } from '../internal/predicates';
+
 export async function first<T>(
     source: AsyncIterable<T>,
-    predicate: (value: T) => boolean | Promise<boolean> = async () => true): Promise<T | undefined> {
+    predicate: booleanAsyncPredicate<T> = async () => true): Promise<T | undefined> {
+  let i = 0;
   for await (let item of source) {
-    if (await predicate(item)) {
+    if (await predicate(item, i++)) {
       return item;
     }
   }

--- a/src/asynciterable/last.ts
+++ b/src/asynciterable/last.ts
@@ -1,9 +1,11 @@
+import { booleanAsyncPredicate } from '../internal/predicates';
+
 export async function last<T>(
     source: AsyncIterable<T>,
-    fn: (value: T) => boolean | Promise<boolean> = async () => true): Promise<T | undefined> {
-  let result: T | undefined;
+    fn: booleanAsyncPredicate<T> = async () => true): Promise<T | undefined> {
+  let i = 0, result: T | undefined;
   for await (let item of source) {
-    if (await fn(item)) {
+    if (await fn(item, i++)) {
       result = item;
     }
   }

--- a/src/asynciterable/partition.ts
+++ b/src/asynciterable/partition.ts
@@ -1,9 +1,10 @@
 import { AsyncIterableX } from '../asynciterable';
 import { filter } from './filter';
+import { booleanAsyncPredicate } from '../internal/predicates';
 
 export function partition<TSource>(
     source: AsyncIterable<TSource>,
-    predicate: (value: TSource, index: number) => boolean | Promise<boolean>,
+    predicate: booleanAsyncPredicate<TSource>,
     thisArg?: any): AsyncIterableX<TSource>[] {
   return [
     filter(source, predicate, thisArg),

--- a/src/asynciterable/single.ts
+++ b/src/asynciterable/single.ts
@@ -1,13 +1,16 @@
+import { booleanAsyncPredicate } from '../internal/predicates';
+
 export async function single<T>(
     source: AsyncIterable<T>,
-    selector: (value: T) => boolean | Promise<boolean> = () => true): Promise<T | undefined> {
+    selector: booleanAsyncPredicate<T> = () => true): Promise<T | undefined> {
   let result: T | undefined;
   let hasResult = false;
+  let i = 0;
   for await (let item of source) {
-    if (hasResult && await selector(item)) {
+    if (hasResult && await selector(item, i++)) {
       throw new Error('More than one element was found');
     }
-    if (await selector(item)) {
+    if (await selector(item, i++)) {
       result = item;
       hasResult = true;
     }

--- a/src/asynciterable/skipwhile.ts
+++ b/src/asynciterable/skipwhile.ts
@@ -1,12 +1,13 @@
 import { AsyncIterableX } from '../asynciterable';
+import { booleanAsyncPredicate } from '../internal/predicates';
 
 class SkipWhileAsyncIterable<TSource> extends AsyncIterableX<TSource> {
   private _source: AsyncIterable<TSource>;
-  private _predicate: (value: TSource, index: number) => boolean | Promise<boolean>;
+  private _predicate: booleanAsyncPredicate<TSource>;
 
   constructor(
       source: AsyncIterable<TSource>,
-      predicate: (value: TSource, index: number) => boolean | Promise<boolean>) {
+      predicate: booleanAsyncPredicate<TSource>) {
     super();
     this._source = source;
     this._predicate = predicate;
@@ -23,6 +24,6 @@ class SkipWhileAsyncIterable<TSource> extends AsyncIterableX<TSource> {
 
 export function skipWhile<TSource>(
     source: AsyncIterable<TSource>,
-    predicate: (value: TSource, index: number) => boolean | Promise<boolean>): AsyncIterableX<TSource> {
+    predicate: booleanAsyncPredicate<TSource>): AsyncIterableX<TSource> {
   return new SkipWhileAsyncIterable<TSource>(source, predicate);
 }

--- a/src/asynciterable/some.ts
+++ b/src/asynciterable/some.ts
@@ -1,6 +1,8 @@
+import { booleanAsyncPredicate } from '../internal/predicates';
+
 export async function some<T>(
     source: AsyncIterable<T>,
-    comparer: (value: T, index: number) => boolean | Promise<boolean>): Promise<boolean> {
+    comparer: booleanAsyncPredicate<T>): Promise<boolean> {
   let i = 0;
   for await (let item of source) {
     if (await comparer(item, i++)) { return true; }

--- a/src/asynciterable/takewhile.ts
+++ b/src/asynciterable/takewhile.ts
@@ -1,12 +1,13 @@
 import { AsyncIterableX } from '../asynciterable';
+import { booleanAsyncPredicate } from '../internal/predicates';
 
 class TakeWhileAsyncIterable<TSource> extends AsyncIterableX<TSource> {
   private _source: AsyncIterable<TSource>;
-  private _predicate: (value: TSource, index: number) => boolean | Promise<boolean>;
+  private _predicate: booleanAsyncPredicate<TSource>;
 
   constructor(
       source: AsyncIterable<TSource>,
-      predicate: (value: TSource, index: number) => boolean | Promise<boolean>) {
+      predicate: booleanAsyncPredicate<TSource>) {
     super();
     this._source = source;
     this._predicate = predicate;
@@ -23,6 +24,6 @@ class TakeWhileAsyncIterable<TSource> extends AsyncIterableX<TSource> {
 
 export function takeWhile<TSource>(
     source: AsyncIterable<TSource>,
-    predicate: (value: TSource, index: number) => boolean| Promise<boolean>): AsyncIterableX<TSource> {
+    predicate: booleanAsyncPredicate<TSource>): AsyncIterableX<TSource> {
   return new TakeWhileAsyncIterable<TSource>(source, predicate);
 }

--- a/src/internal/predicates.ts
+++ b/src/internal/predicates.ts
@@ -1,0 +1,8 @@
+export type booleanPredicate<T> =
+{ (value: T, index: number): boolean } |
+{ (value: T, index: number): value is T };
+
+export type booleanAsyncPredicate<T> =
+{ (value: T, index: number): boolean } |
+{ (value: T, index: number): value is T } |
+{ (value: T, index: number): Promise<boolean> } ;

--- a/src/iterable/every.ts
+++ b/src/iterable/every.ts
@@ -1,3 +1,4 @@
+import { booleanPredicate } from '../internal/predicates';
 /**
  * Determines whether every element of a sequence satisfy a condition.
  * @param {Iterable<T>} source Source sequence.
@@ -7,7 +8,7 @@
  */
 export function every<T>(
     source: Iterable<T>,
-    comparer: (value: T, index: number) => boolean): boolean {
+    comparer: booleanPredicate<T>): boolean {
   let i = 0;
   for (let item of source) {
     if (!comparer(item, i++)) { return false; }

--- a/src/iterable/filter.ts
+++ b/src/iterable/filter.ts
@@ -1,5 +1,6 @@
 import { IterableX } from '../iterable';
 import { bindCallback } from '../internal/bindcallback';
+import { booleanPredicate } from '../internal/predicates';
 
 class FilterIterable<TSource> extends IterableX<TSource> {
   private _source: Iterable<TSource>;
@@ -30,7 +31,7 @@ class FilterIterable<TSource> extends IterableX<TSource> {
  */
 export function filter<T>(
     source: Iterable<T>,
-    predicate: (value: T, index: number) => boolean,
+    predicate: booleanPredicate<T>,
     thisArg?: any): IterableX<T> {
   return new FilterIterable<T>(source, bindCallback(predicate, thisArg, 2));
 }

--- a/src/iterable/filterasync.ts
+++ b/src/iterable/filterasync.ts
@@ -1,5 +1,6 @@
 import { AsyncIterableX } from '../asynciterable';
 import { bindCallback } from '../internal/bindcallback';
+import { booleanAsyncPredicate } from '../internal/predicates';
 
 class FilterIterable<TSource> extends AsyncIterableX<TSource> {
   private _source: Iterable<TSource | PromiseLike<TSource>> | AsyncIterable<TSource>;
@@ -32,7 +33,7 @@ class FilterIterable<TSource> extends AsyncIterableX<TSource> {
 */
 export function filterAsync<TSource>(
     source: Iterable<TSource | PromiseLike<TSource>> | AsyncIterable<TSource>,
-    predicate: (value: TSource, index: number) => boolean | Promise<boolean>,
+    predicate: booleanAsyncPredicate<TSource>,
     thisArg?: any): AsyncIterableX<TSource> {
   return new FilterIterable<TSource>(source, bindCallback(predicate, thisArg, 2));
 }

--- a/src/iterable/find.ts
+++ b/src/iterable/find.ts
@@ -1,4 +1,5 @@
 import { bindCallback } from '../internal/bindcallback';
+import { booleanPredicate } from '../internal/predicates';
 
 /**
  * Returns the value of the first element in the sequence that satisfies the provided testing function.
@@ -11,7 +12,7 @@ import { bindCallback } from '../internal/bindcallback';
  */
 export function find<T>(
     source: Iterable<T>,
-    predicate: (value: T, index: number) => boolean,
+    predicate: booleanPredicate<T>,
     thisArg?: any): T | undefined {
   if (typeof predicate !== 'function') { throw new TypeError(); }
   const f = bindCallback(predicate, thisArg, 2);

--- a/src/iterable/findindex.ts
+++ b/src/iterable/findindex.ts
@@ -1,6 +1,7 @@
 import { bindCallback } from '../internal/bindcallback';
+import { booleanPredicate } from '../internal/predicates';
 
-export function findIndex<T>(source: Iterable<T>, fn: (value: T, index: number) => boolean, thisArg?: any): number {
+export function findIndex<T>(source: Iterable<T>, fn: booleanPredicate<T>, thisArg?: any): number {
   if (typeof fn !== 'function') { throw new TypeError(); }
   const f = bindCallback(fn, thisArg, 2);
   let i = 0;

--- a/src/iterable/first.ts
+++ b/src/iterable/first.ts
@@ -1,3 +1,5 @@
+import { booleanPredicate } from '../internal/predicates';
+
 /**
  * Returns the first element in a sequence that satisfies a specified condition if provided, else
  * the first element in the sequence.
@@ -9,9 +11,10 @@
  */
 export function first<T>(
     source: Iterable<T>,
-    selector: (value: T) => boolean = () => true): T | undefined {
+    selector: booleanPredicate<T> = () => true): T | undefined {
+  let i = 0;
   for (let item of source) {
-    if (selector(item)) {
+    if (selector(item, i++)) {
       return item;
     }
   }

--- a/src/iterable/last.ts
+++ b/src/iterable/last.ts
@@ -1,7 +1,9 @@
-export function last<T>(source: Iterable<T>, fn: (value: T) => boolean = () => true): T | undefined {
-  let result: T | undefined;
+import { booleanPredicate } from '../internal/predicates';
+
+export function last<T>(source: Iterable<T>, fn: booleanPredicate<T> = () => true): T | undefined {
+  let i = 0, result: T | undefined;
   for (let item of source) {
-    if (fn(item)) {
+    if (fn(item, i++)) {
       result = item;
     }
   }

--- a/src/iterable/single.ts
+++ b/src/iterable/single.ts
@@ -1,11 +1,14 @@
-export function single<T>(source: Iterable<T>, fn: (value: T) => boolean = () => true): T | undefined {
+import { booleanPredicate } from '../internal/predicates';
+
+export function single<T>(source: Iterable<T>, fn: booleanPredicate<T> = () => true): T | undefined {
   let result: T | undefined;
   let hasResult = false;
+  let i = 0;
   for (let item of source) {
-    if (hasResult && fn(item)) {
+    if (hasResult && fn(item, i++)) {
       throw new Error('More than one element was found');
     }
-    if (fn(item)) {
+    if (fn(item, i++)) {
       result = item;
       hasResult = true;
     }

--- a/src/iterable/skipwhile.ts
+++ b/src/iterable/skipwhile.ts
@@ -1,10 +1,11 @@
 import { IterableX } from '../iterable';
+import { booleanPredicate } from '../internal/predicates';
 
 class SkipWhileIterable<TSource> extends IterableX<TSource> {
   private _source: Iterable<TSource>;
-  private _predicate: (value: TSource, index: number) => boolean;
+  private _predicate: booleanPredicate<TSource>;
 
-  constructor(source: Iterable<TSource>, predicate: (value: TSource, index: number) => boolean) {
+  constructor(source: Iterable<TSource>, predicate: booleanPredicate<TSource>) {
     super();
     this._source = source;
     this._predicate = predicate;
@@ -21,6 +22,6 @@ class SkipWhileIterable<TSource> extends IterableX<TSource> {
 
 export function skipWhile<TSource>(
     source: Iterable<TSource>,
-    predicate: (value: TSource, index: number) => boolean): IterableX<TSource> {
+    predicate: booleanPredicate<TSource>): IterableX<TSource> {
   return new SkipWhileIterable<TSource>(source, predicate);
 }

--- a/src/iterable/some.ts
+++ b/src/iterable/some.ts
@@ -1,6 +1,8 @@
+import { booleanPredicate } from '../internal/predicates';
+
 export function some<T>(
     source: Iterable<T>,
-    comparer: (value: T, index: number) => boolean): boolean {
+    comparer: booleanPredicate<T>): boolean {
   let i = 0;
   for (let item of source) {
     if (comparer(item, i++)) { return true; }

--- a/src/iterable/takewhile.ts
+++ b/src/iterable/takewhile.ts
@@ -1,8 +1,9 @@
 import { IterableX } from '../iterable';
+import { booleanPredicate } from '../internal/predicates';
 
 class TakeWhileIterable<TSource> extends IterableX<TSource> {
   private _source: Iterable<TSource>;
-  private _predicate: (value: TSource, index: number) => boolean;
+  private _predicate: booleanPredicate<TSource>;
 
   constructor(source: Iterable<TSource>, predicate: (value: TSource, index: number) => boolean) {
     super();
@@ -21,6 +22,6 @@ class TakeWhileIterable<TSource> extends IterableX<TSource> {
 
 export function takeWhile<TSource>(
     source: Iterable<TSource>,
-    predicate: (value: TSource, index: number) => boolean): IterableX<TSource> {
+    predicate: booleanPredicate<TSource>): IterableX<TSource> {
   return new TakeWhileIterable<TSource>(source, predicate);
 }


### PR DESCRIPTION
resolves #44 

@mattpodwysocki this also adds a second `index` arg to the [first](https://github.com/ReactiveX/IxJS/compare/user-defined-typeguards?expand=1#diff-12ca01854ada962ba2d5329e03510696) and last predicate selectors. I can remove these, but it seems useful too