### PR TITLE
docs(chain-operator): add methods to require statements for chain operator example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -117,9 +117,9 @@ import { map } from 'ix/iterable/map';
 // CommonJS
 const Iterable = require('ix/iterable').IterableX;
 require('ix/add/iterable-operators/chain');
-const of = require('ix/iterable/of');
-const filter = require('ix/iterable/filter');
-const map = require('ix/iterable/map');
+const of = require('ix/iterable/of').of;
+const filter = require('ix/iterable/filter').filter;
+const map = require('ix/iterable/map').map;
 
 const results = of(1, 2, 3)
   .chain(source => filter(source, x => x % 2 === 0))


### PR DESCRIPTION

<!--
Thank you very much for your pull request!
-->

**Description:**
This PR ensures that the chain operator example from the docs can be run without encountering `map is not a function` errors in a CommonJS environment.

**Related issue (if exists):**
fix #78 