### PR TITLE
feat(merge/concat): add typed overloads for merge/concat

### DIFF
--- a/src/add/asynciterable-operators/concat.ts
+++ b/src/add/asynciterable-operators/concat.ts
@@ -1,6 +1,58 @@
 import { AsyncIterableX } from '../../asynciterable';
 import { concat } from '../../asynciterable/concat';
 
+/* tslint:disable:max-line-length */
+/**
+ * @ignore
+ */
+export function concatProto<T>(this: AsyncIterableX<T>): AsyncIterableX<T>;
+/**
+ * @ignore
+ */
+export function concatProto<T, T2>(
+  this: AsyncIterableX<T>,
+  v2: AsyncIterable<T2>
+): AsyncIterableX<T | T2>;
+/**
+ * @ignore
+ */
+export function concatProto<T, T2, T3>(
+  this: AsyncIterableX<T>,
+  v2: AsyncIterable<T2>,
+  v3: AsyncIterable<T3>
+): AsyncIterableX<T | T2 | T3>;
+/**
+ * @ignore
+ */
+export function concatProto<T, T2, T3, T4>(
+  this: AsyncIterableX<T>,
+  v2: AsyncIterable<T2>,
+  v3: AsyncIterable<T3>,
+  v4: AsyncIterable<T4>
+): AsyncIterableX<T | T2 | T3 | T4>;
+/**
+ * @ignore
+ */
+export function concatProto<T, T2, T3, T4, T5>(
+  this: AsyncIterableX<T>,
+  v2: AsyncIterable<T2>,
+  v3: AsyncIterable<T3>,
+  v4: AsyncIterable<T4>,
+  v5: AsyncIterable<T5>
+): AsyncIterable<T | T2 | T3 | T4 | T5>;
+/**
+ * @ignore
+ */
+export function concatProto<T, T2, T3, T4, T5, T6>(
+  this: AsyncIterableX<T>,
+  v2: AsyncIterable<T2>,
+  v3: AsyncIterable<T3>,
+  v4: AsyncIterable<T4>,
+  v5: AsyncIterable<T5>,
+  v6: AsyncIterable<T6>
+): AsyncIterable<T | T2 | T3 | T4 | T5 | T6>;
+/* tslint:enable:max-line-length */
+
 /**
  * @ignore
  */

--- a/src/add/asynciterable-operators/concatall.ts
+++ b/src/add/asynciterable-operators/concatall.ts
@@ -1,5 +1,5 @@
 import { AsyncIterableX } from '../../asynciterable';
-import { concatAll } from '../../asynciterable/concat';
+import { concatAll } from '../../asynciterable/concatall';
 
 /**
  * @ignore

--- a/src/add/asynciterable-operators/merge.ts
+++ b/src/add/asynciterable-operators/merge.ts
@@ -2,22 +2,37 @@ import { AsyncIterableX } from '../../asynciterable';
 import { merge } from '../../asynciterable/merge';
 
 /* tslint:disable:max-line-length */
+/**
+ * @ignore
+ */
 export function mergeProto<T>(this: AsyncIterableX<T>): AsyncIterableX<T>;
+/**
+ * @ignore
+ */
 export function mergeProto<T, T2>(
   this: AsyncIterableX<T>,
   v2: AsyncIterable<T2>
 ): AsyncIterableX<T | T2>;
+/**
+ * @ignore
+ */
 export function mergeProto<T, T2, T3>(
   this: AsyncIterableX<T>,
   v2: AsyncIterable<T2>,
   v3: AsyncIterable<T3>
 ): AsyncIterableX<T | T2 | T3>;
+/**
+ * @ignore
+ */
 export function mergeProto<T, T2, T3, T4>(
   this: AsyncIterableX<T>,
   v2: AsyncIterable<T2>,
   v3: AsyncIterable<T3>,
   v4: AsyncIterable<T4>
 ): AsyncIterableX<T | T2 | T3 | T4>;
+/**
+ * @ignore
+ */
 export function mergeProto<T, T2, T3, T4, T5>(
   this: AsyncIterableX<T>,
   v2: AsyncIterable<T2>,
@@ -25,6 +40,9 @@ export function mergeProto<T, T2, T3, T4, T5>(
   v4: AsyncIterable<T4>,
   v5: AsyncIterable<T5>
 ): AsyncIterable<T | T2 | T3 | T4 | T5>;
+/**
+ * @ignore
+ */
 export function mergeProto<T, T2, T3, T4, T5, T6>(
   this: AsyncIterableX<T>,
   v2: AsyncIterable<T2>,

--- a/src/add/asynciterable-operators/merge.ts
+++ b/src/add/asynciterable-operators/merge.ts
@@ -1,6 +1,40 @@
 import { AsyncIterableX } from '../../asynciterable';
 import { merge } from '../../asynciterable/merge';
 
+/* tslint:disable:max-line-length */
+export function mergeProto<T>(this: AsyncIterableX<T>): AsyncIterableX<T>;
+export function mergeProto<T, T2>(
+  this: AsyncIterableX<T>,
+  v2: AsyncIterable<T2>
+): AsyncIterableX<T | T2>;
+export function mergeProto<T, T2, T3>(
+  this: AsyncIterableX<T>,
+  v2: AsyncIterable<T2>,
+  v3: AsyncIterable<T3>
+): AsyncIterableX<T | T2 | T3>;
+export function mergeProto<T, T2, T3, T4>(
+  this: AsyncIterableX<T>,
+  v2: AsyncIterable<T2>,
+  v3: AsyncIterable<T3>,
+  v4: AsyncIterable<T4>
+): AsyncIterableX<T | T2 | T3 | T4>;
+export function mergeProto<T, T2, T3, T4, T5>(
+  this: AsyncIterableX<T>,
+  v2: AsyncIterable<T2>,
+  v3: AsyncIterable<T3>,
+  v4: AsyncIterable<T4>,
+  v5: AsyncIterable<T5>
+): AsyncIterable<T | T2 | T3 | T4 | T5>;
+export function mergeProto<T, T2, T3, T4, T5, T6>(
+  this: AsyncIterableX<T>,
+  v2: AsyncIterable<T2>,
+  v3: AsyncIterable<T3>,
+  v4: AsyncIterable<T4>,
+  v5: AsyncIterable<T5>,
+  v6: AsyncIterable<T6>
+): AsyncIterable<T | T2 | T3 | T4 | T5 | T6>;
+/* tslint:enable:max-line-length */
+
 /**
  * @ignore
  */

--- a/src/add/asynciterable-operators/mergeall.ts
+++ b/src/add/asynciterable-operators/mergeall.ts
@@ -1,5 +1,5 @@
 import { AsyncIterableX } from '../../asynciterable';
-import { mergeAll } from '../../asynciterable/merge';
+import { mergeAll } from '../../asynciterable/mergeall';
 
 /**
  * @ignore

--- a/src/add/iterable-operators/concat.ts
+++ b/src/add/iterable-operators/concat.ts
@@ -1,6 +1,37 @@
 import { IterableX } from '../../iterable';
 import { concat } from '../../iterable/concat';
 
+/* tslint:disable:max-line-length */
+export function concatProto<T>(this: IterableX<T>): IterableX<T>;
+export function concatProto<T, T2>(this: IterableX<T>, v2: Iterable<T2>): IterableX<T | T2>;
+export function concatProto<T, T2, T3>(
+  this: IterableX<T>,
+  v2: Iterable<T2>,
+  v3: Iterable<T3>
+): IterableX<T | T2 | T3>;
+export function concatProto<T, T2, T3, T4>(
+  this: IterableX<T>,
+  v2: Iterable<T2>,
+  v3: Iterable<T3>,
+  v4: Iterable<T4>
+): IterableX<T | T2 | T3 | T4>;
+export function concatProto<T, T2, T3, T4, T5>(
+  this: IterableX<T>,
+  v2: Iterable<T2>,
+  v3: Iterable<T3>,
+  v4: Iterable<T4>,
+  v5: Iterable<T5>
+): Iterable<T | T2 | T3 | T4 | T5>;
+export function concatProto<T, T2, T3, T4, T5, T6>(
+  this: IterableX<T>,
+  v2: Iterable<T2>,
+  v3: Iterable<T3>,
+  v4: Iterable<T4>,
+  v5: Iterable<T5>,
+  v6: Iterable<T6>
+): Iterable<T | T2 | T3 | T4 | T5 | T6>;
+/* tslint:enable:max-line-length */
+
 /**
  * @ignore
  */

--- a/src/add/iterable-operators/concat.ts
+++ b/src/add/iterable-operators/concat.ts
@@ -2,19 +2,31 @@ import { IterableX } from '../../iterable';
 import { concat } from '../../iterable/concat';
 
 /* tslint:disable:max-line-length */
+/**
+ * @ignore
+ */
 export function concatProto<T>(this: IterableX<T>): IterableX<T>;
+/**
+ * @ignore
+ */
 export function concatProto<T, T2>(this: IterableX<T>, v2: Iterable<T2>): IterableX<T | T2>;
 export function concatProto<T, T2, T3>(
   this: IterableX<T>,
   v2: Iterable<T2>,
   v3: Iterable<T3>
 ): IterableX<T | T2 | T3>;
+/**
+ * @ignore
+ */
 export function concatProto<T, T2, T3, T4>(
   this: IterableX<T>,
   v2: Iterable<T2>,
   v3: Iterable<T3>,
   v4: Iterable<T4>
 ): IterableX<T | T2 | T3 | T4>;
+/**
+ * @ignore
+ */
 export function concatProto<T, T2, T3, T4, T5>(
   this: IterableX<T>,
   v2: Iterable<T2>,
@@ -22,6 +34,9 @@ export function concatProto<T, T2, T3, T4, T5>(
   v4: Iterable<T4>,
   v5: Iterable<T5>
 ): Iterable<T | T2 | T3 | T4 | T5>;
+/**
+ * @ignore
+ */
 export function concatProto<T, T2, T3, T4, T5, T6>(
   this: IterableX<T>,
   v2: Iterable<T2>,

--- a/src/add/iterable-operators/concatall.ts
+++ b/src/add/iterable-operators/concatall.ts
@@ -1,5 +1,5 @@
 import { IterableX } from '../../iterable';
-import { concatAll } from '../../iterable/concat';
+import { concatAll } from '../../iterable/concatall';
 
 /**
  * @ignore

--- a/src/asynciterable/__modules.ts
+++ b/src/asynciterable/__modules.ts
@@ -59,7 +59,7 @@ import { max } from './max';
 import { maxBy } from './maxby';
 import { memoize } from './memoize';
 import { merge } from './merge';
-import { mergeAll } from './merge';
+import { mergeAll } from './mergeall';
 import { min } from './min';
 import { minBy } from './minby';
 import { of } from './of';

--- a/src/asynciterable/__modules.ts
+++ b/src/asynciterable/__modules.ts
@@ -15,7 +15,7 @@ import { _catchStatic } from './catch';
 import { catchWith } from './catchwith';
 import { chain } from './chain';
 import { concat } from './concat';
-import { concatAll } from './concat';
+import { concatAll } from './concatall';
 import { concatStatic } from './concat';
 import { count } from './count';
 import { create } from './create';

--- a/src/asynciterable/concat.ts
+++ b/src/asynciterable/concat.ts
@@ -1,22 +1,5 @@
 import { AsyncIterableX } from '../asynciterable';
 
-class ConcatAllAsyncIterable<TSource> extends AsyncIterableX<TSource> {
-  private _source: AsyncIterable<AsyncIterable<TSource>>;
-
-  constructor(source: AsyncIterable<AsyncIterable<TSource>>) {
-    super();
-    this._source = source;
-  }
-
-  async *[Symbol.asyncIterator]() {
-    for await (let outer of this._source) {
-      for await (let item of outer) {
-        yield item;
-      }
-    }
-  }
-}
-
 class ConcatAsyncIterable<TSource> extends AsyncIterableX<TSource> {
   private _source: Iterable<AsyncIterable<TSource>>;
 
@@ -34,17 +17,45 @@ class ConcatAsyncIterable<TSource> extends AsyncIterableX<TSource> {
   }
 }
 
-export function concatAll<TSource>(
-  source: AsyncIterable<AsyncIterable<TSource>>
-): AsyncIterableX<TSource> {
-  return new ConcatAllAsyncIterable<TSource>(source);
-}
-
 export function _concatAll<TSource>(
   source: Iterable<AsyncIterable<TSource>>
 ): AsyncIterableX<TSource> {
   return new ConcatAsyncIterable<TSource>(source);
 }
+
+/* tslint:disable:max-line-length */
+export function concat<T>(source: AsyncIterable<T>): AsyncIterableX<T>;
+export function concat<T, T2>(
+  source: AsyncIterable<T>,
+  v2: AsyncIterable<T2>
+): AsyncIterableX<T | T2>;
+export function concat<T, T2, T3>(
+  source: AsyncIterable<T>,
+  v2: AsyncIterable<T2>,
+  v3: AsyncIterable<T3>
+): AsyncIterableX<T | T2 | T3>;
+export function concat<T, T2, T3, T4>(
+  source: AsyncIterable<T>,
+  v2: AsyncIterable<T2>,
+  v3: AsyncIterable<T3>,
+  v4: AsyncIterable<T4>
+): AsyncIterableX<T | T2 | T3 | T4>;
+export function concat<T, T2, T3, T4, T5>(
+  source: AsyncIterable<T>,
+  v2: AsyncIterable<T2>,
+  v3: AsyncIterable<T3>,
+  v4: AsyncIterable<T4>,
+  v5: AsyncIterable<T5>
+): AsyncIterable<T | T2 | T3 | T4 | T5>;
+export function concat<T, T2, T3, T4, T5, T6>(
+  source: AsyncIterable<T>,
+  v2: AsyncIterable<T2>,
+  v3: AsyncIterable<T3>,
+  v4: AsyncIterable<T4>,
+  v5: AsyncIterable<T5>,
+  v6: AsyncIterable<T6>
+): AsyncIterable<T | T2 | T3 | T4 | T5 | T6>;
+/* tslint:enable:max-line-length */
 
 export function concat<T>(
   source: AsyncIterable<T>,
@@ -52,6 +63,40 @@ export function concat<T>(
 ): AsyncIterableX<T> {
   return new ConcatAsyncIterable<T>([source, ...args]);
 }
+
+/* tslint:disable:max-line-length */
+export function concatStatic<T>(v1: AsyncIterable<T>): AsyncIterableX<T>;
+export function concatStatic<T, T2>(
+  v1: AsyncIterable<T>,
+  v2: AsyncIterable<T2>
+): AsyncIterableX<T | T2>;
+export function concatStatic<T, T2, T3>(
+  v1: AsyncIterable<T>,
+  v2: AsyncIterable<T2>,
+  v3: AsyncIterable<T3>
+): AsyncIterableX<T | T2 | T3>;
+export function concatStatic<T, T2, T3, T4>(
+  v1: AsyncIterable<T>,
+  v2: AsyncIterable<T2>,
+  v3: AsyncIterable<T3>,
+  v4: AsyncIterable<T4>
+): AsyncIterableX<T | T2 | T3 | T4>;
+export function concatStatic<T, T2, T3, T4, T5>(
+  v1: AsyncIterable<T>,
+  v2: AsyncIterable<T2>,
+  v3: AsyncIterable<T3>,
+  v4: AsyncIterable<T4>,
+  v5: AsyncIterable<T5>
+): AsyncIterable<T | T2 | T3 | T4 | T5>;
+export function concatStatic<T, T2, T3, T4, T5, T6>(
+  v1: AsyncIterable<T>,
+  v2: AsyncIterable<T2>,
+  v3: AsyncIterable<T3>,
+  v4: AsyncIterable<T4>,
+  v5: AsyncIterable<T5>,
+  v6: AsyncIterable<T6>
+): AsyncIterable<T | T2 | T3 | T4 | T5 | T6>;
+/* tslint:enable:max-line-length */
 
 export function concatStatic<T>(...args: AsyncIterable<T>[]): AsyncIterableX<T> {
   return new ConcatAsyncIterable<T>(args);

--- a/src/asynciterable/concatall.ts
+++ b/src/asynciterable/concatall.ts
@@ -1,0 +1,24 @@
+import { AsyncIterableX } from '../asynciterable';
+
+class ConcatAllAsyncIterable<TSource> extends AsyncIterableX<TSource> {
+  private _source: AsyncIterable<AsyncIterable<TSource>>;
+
+  constructor(source: AsyncIterable<AsyncIterable<TSource>>) {
+    super();
+    this._source = source;
+  }
+
+  async *[Symbol.asyncIterator]() {
+    for await (let outer of this._source) {
+      for await (let item of outer) {
+        yield item;
+      }
+    }
+  }
+}
+
+export function concatAll<TSource>(
+  source: AsyncIterable<AsyncIterable<TSource>>
+): AsyncIterableX<TSource> {
+  return new ConcatAllAsyncIterable<TSource>(source);
+}

--- a/src/asynciterable/for.ts
+++ b/src/asynciterable/for.ts
@@ -1,5 +1,5 @@
 import { AsyncIterableX } from '../asynciterable';
-import { concatAll } from './concat';
+import { concatAll } from './concatall';
 import { map } from './map';
 
 export function _for<TSource, TResult>(

--- a/src/asynciterable/merge.ts
+++ b/src/asynciterable/merge.ts
@@ -1,6 +1,4 @@
 import { AsyncIterableX } from '../asynciterable';
-import { flatMap } from './flatmap';
-import { from } from './from';
 
 // tslint:disable-next-line:no-empty
 const NEVER_PROMISE = new Promise(() => {});
@@ -45,21 +43,77 @@ class MergeAsyncIterable<T> extends AsyncIterableX<T> {
   }
 }
 
-export function mergeAll<TSource>(
-  source: AsyncIterable<AsyncIterable<TSource>>
-): AsyncIterableX<TSource> {
-  return flatMap(source, source => source);
-}
-
-export function _mergeAll<TSource>(
-  source: Iterable<AsyncIterable<TSource>>
-): AsyncIterableX<TSource> {
-  return flatMap(from(source), source => source);
-}
+/* tslint:disable:max-line-length */
+export function merge<T>(source: AsyncIterable<T>): AsyncIterableX<T>;
+export function merge<T, T2>(
+  source: AsyncIterable<T>,
+  v2: AsyncIterable<T2>
+): AsyncIterableX<T | T2>;
+export function merge<T, T2, T3>(
+  source: AsyncIterable<T>,
+  v2: AsyncIterable<T2>,
+  v3: AsyncIterable<T3>
+): AsyncIterableX<T | T2 | T3>;
+export function merge<T, T2, T3, T4>(
+  source: AsyncIterable<T>,
+  v2: AsyncIterable<T2>,
+  v3: AsyncIterable<T3>,
+  v4: AsyncIterable<T4>
+): AsyncIterableX<T | T2 | T3 | T4>;
+export function merge<T, T2, T3, T4, T5>(
+  source: AsyncIterable<T>,
+  v2: AsyncIterable<T2>,
+  v3: AsyncIterable<T3>,
+  v4: AsyncIterable<T4>,
+  v5: AsyncIterable<T5>
+): AsyncIterable<T | T2 | T3 | T4 | T5>;
+export function merge<T, T2, T3, T4, T5, T6>(
+  source: AsyncIterable<T>,
+  v2: AsyncIterable<T2>,
+  v3: AsyncIterable<T3>,
+  v4: AsyncIterable<T4>,
+  v5: AsyncIterable<T5>,
+  v6: AsyncIterable<T6>
+): AsyncIterable<T | T2 | T3 | T4 | T5 | T6>;
+/* tslint:enable:max-line-length */
 
 export function merge<T>(source: AsyncIterable<T>, ...args: AsyncIterable<T>[]): AsyncIterableX<T> {
   return new MergeAsyncIterable<T>([source, ...args]);
 }
+
+/* tslint:disable:max-line-length */
+export function mergeStatic<T>(v1: AsyncIterable<T>): AsyncIterableX<T>;
+export function mergeStatic<T, T2>(
+  v1: AsyncIterable<T>,
+  v2: AsyncIterable<T2>
+): AsyncIterableX<T | T2>;
+export function mergeStatic<T, T2, T3>(
+  v1: AsyncIterable<T>,
+  v2: AsyncIterable<T2>,
+  v3: AsyncIterable<T3>
+): AsyncIterableX<T | T2 | T3>;
+export function mergeStatic<T, T2, T3, T4>(
+  v1: AsyncIterable<T>,
+  v2: AsyncIterable<T2>,
+  v3: AsyncIterable<T3>,
+  v4: AsyncIterable<T4>
+): AsyncIterableX<T | T2 | T3 | T4>;
+export function mergeStatic<T, T2, T3, T4, T5>(
+  v1: AsyncIterable<T>,
+  v2: AsyncIterable<T2>,
+  v3: AsyncIterable<T3>,
+  v4: AsyncIterable<T4>,
+  v5: AsyncIterable<T5>
+): AsyncIterable<T | T2 | T3 | T4 | T5>;
+export function mergeStatic<T, T2, T3, T4, T5, T6>(
+  v1: AsyncIterable<T>,
+  v2: AsyncIterable<T2>,
+  v3: AsyncIterable<T3>,
+  v4: AsyncIterable<T4>,
+  v5: AsyncIterable<T5>,
+  v6: AsyncIterable<T6>
+): AsyncIterable<T | T2 | T3 | T4 | T5 | T6>;
+/* tslint:enable:max-line-length */
 
 export function mergeStatic<T>(...args: AsyncIterable<T>[]): AsyncIterableX<T> {
   return new MergeAsyncIterable<T>(args);

--- a/src/asynciterable/mergeall.ts
+++ b/src/asynciterable/mergeall.ts
@@ -1,0 +1,8 @@
+import { AsyncIterableX } from '../asynciterable';
+import { flatMap } from './flatmap';
+
+export function mergeAll<TSource>(
+  source: AsyncIterable<AsyncIterable<TSource>>
+): AsyncIterableX<TSource> {
+  return flatMap(source, source => source);
+}

--- a/src/iterable/__modules.ts
+++ b/src/iterable/__modules.ts
@@ -15,7 +15,7 @@ import { _catchStatic } from './catch';
 import { catchWith } from './catchwith';
 import { chain } from './chain';
 import { concat } from './concat';
-import { concatAll } from './concat';
+import { concatAll } from './concatall';
 import { concatStatic } from './concat';
 import { count } from './count';
 import { create } from './create';

--- a/src/iterable/concat.ts
+++ b/src/iterable/concat.ts
@@ -1,6 +1,6 @@
 import { IterableX } from '../iterable';
 
-class ConcatIterable<TSource> extends IterableX<TSource> {
+export class ConcatIterable<TSource> extends IterableX<TSource> {
   private _source: Iterable<Iterable<TSource>>;
 
   constructor(source: Iterable<Iterable<TSource>>) {
@@ -15,30 +15,72 @@ class ConcatIterable<TSource> extends IterableX<TSource> {
   }
 }
 
-/**
- * Concatenates the input sequences.
- * @param {Iterable<Iterable<TSource>>} source Source sequences.
- * @return {Iterable<TSource>} Sequence with the elements of the source sequences concatenated.
- */
-export function concatAll<TSource>(source: Iterable<Iterable<TSource>>): IterableX<TSource> {
-  return new ConcatIterable<TSource>(source);
-}
+/* tslint:disable:max-line-length */
+export function concat<T>(source: Iterable<T>): IterableX<T>;
+export function concat<T, T2>(source: Iterable<T>, v2: Iterable<T2>): IterableX<T | T2>;
+export function concat<T, T2, T3>(
+  source: Iterable<T>,
+  v2: Iterable<T2>,
+  v3: Iterable<T3>
+): IterableX<T | T2 | T3>;
+export function concat<T, T2, T3, T4>(
+  source: Iterable<T>,
+  v2: Iterable<T2>,
+  v3: Iterable<T3>,
+  v4: Iterable<T4>
+): IterableX<T | T2 | T3 | T4>;
+export function concat<T, T2, T3, T4, T5>(
+  source: Iterable<T>,
+  v2: Iterable<T2>,
+  v3: Iterable<T3>,
+  v4: Iterable<T4>,
+  v5: Iterable<T5>
+): Iterable<T | T2 | T3 | T4 | T5>;
+export function concat<T, T2, T3, T4, T5, T6>(
+  source: Iterable<T>,
+  v2: Iterable<T2>,
+  v3: Iterable<T3>,
+  v4: Iterable<T4>,
+  v5: Iterable<T5>,
+  v6: Iterable<T6>
+): Iterable<T | T2 | T3 | T4 | T5 | T6>;
+/* tslint:enable:max-line-length */
 
-/**
- * Concatenates the input sequences.
- * @param {Iterable<TSource>} source The first source sequence.
- * @param {...Iterable<TSource>} args The rest of the source sequences.
- * @return {Iterable<TSource>} Sequence with the elements of the source sequences concatenated.
- */
 export function concat<T>(source: Iterable<T>, ...args: Iterable<T>[]): IterableX<T> {
-  return new ConcatIterable([source, ...args]);
+  return new ConcatIterable<T>([source, ...args]);
 }
 
-/**
- * Concatenates the input sequences.
- * @param {...Iterable<TSource>} args Source sequences.
- * @return {Iterable<TSource>} Sequence with the elements of the source sequences concatenated.
- */
+/* tslint:disable:max-line-length */
+export function concatStatic<T>(v1: Iterable<T>): IterableX<T>;
+export function concatStatic<T, T2>(v1: Iterable<T>, v2: Iterable<T2>): IterableX<T | T2>;
+export function concatStatic<T, T2, T3>(
+  v1: Iterable<T>,
+  v2: Iterable<T2>,
+  v3: Iterable<T3>
+): IterableX<T | T2 | T3>;
+export function concatStatic<T, T2, T3, T4>(
+  v1: Iterable<T>,
+  v2: Iterable<T2>,
+  v3: Iterable<T3>,
+  v4: Iterable<T4>
+): IterableX<T | T2 | T3 | T4>;
+export function concatStatic<T, T2, T3, T4, T5>(
+  v1: Iterable<T>,
+  v2: Iterable<T2>,
+  v3: Iterable<T3>,
+  v4: Iterable<T4>,
+  v5: Iterable<T5>
+): Iterable<T | T2 | T3 | T4 | T5>;
+export function concatStatic<T, T2, T3, T4, T5, T6>(
+  v1: Iterable<T>,
+  v2: Iterable<T2>,
+  v3: Iterable<T3>,
+  v4: Iterable<T4>,
+  v5: Iterable<T5>,
+  v6: Iterable<T6>
+): Iterable<T | T2 | T3 | T4 | T5 | T6>;
+/* tslint:enable:max-line-length */
+
 export function concatStatic<T>(...args: Iterable<T>[]): IterableX<T> {
-  return new ConcatIterable(args);
+  return new ConcatIterable<T>(args);
 }

--- a/src/iterable/concatall.ts
+++ b/src/iterable/concatall.ts
@@ -1,0 +1,11 @@
+import { IterableX } from '../iterable';
+import { ConcatIterable } from './concat';
+
+/**
+ * Concatenates the input sequences.
+ * @param {Iterable<Iterable<TSource>>} source Source sequences.
+ * @return {Iterable<TSource>} Sequence with the elements of the source sequences concatenated.
+ */
+export function concatAll<TSource>(source: Iterable<Iterable<TSource>>): IterableX<TSource> {
+  return new ConcatIterable<TSource>(source);
+}

--- a/src/iterable/for.ts
+++ b/src/iterable/for.ts
@@ -1,5 +1,5 @@
 import { IterableX } from '../iterable';
-import { concatAll } from './concat';
+import { concatAll } from './concatall';
 import { map } from './map';
 
 /**


### PR DESCRIPTION
<!--
Thank you very much for your pull request!
-->

**Description:**

Adds TypeScript overloads for `AsyncIterable` `concat` and `merge`, as well as `Iterable` `concat`.  Also splits files for `concat` and `concatAll`, `merge` and `mergeAll`.

**Related issue (if exists):**