### PR TITLE
feat(asyncify): adds asyncify and asyncifyErrback

### DIFF
--- a/spec/asynciterable/asyncify-spec.ts
+++ b/spec/asynciterable/asyncify-spec.ts
@@ -1,0 +1,35 @@
+import * as Ix from '../Ix';
+import * as test from 'tape-async';
+const { asyncify } = Ix.asynciterable;
+const { sequenceEqual } = Ix.iterable;
+import { hasNext, noNext } from '../asynciterablehelpers';
+
+test('AsyncIterable#asyncify single argument', async t => {
+  const callbackFn = (a: number, b: number, cb: Function) => {
+    cb(a + b);
+  };
+
+  const asyncFn = asyncify(callbackFn);
+  const xs = asyncFn(1, 2);
+
+  const it = xs[Symbol.asyncIterator]();
+  await hasNext(t, it, 3);
+  await noNext(t, it);
+  t.end();
+});
+
+test('AsyncIterable#asyncify multiple arguments', async t => {
+  const callbackFn = (a: number, b: number, cb: Function) => {
+    cb(a, b);
+  };
+
+  const asyncFn = asyncify(callbackFn);
+  const xs = asyncFn(1, 2);
+
+  const it = xs[Symbol.asyncIterator]();
+  const { value, done } = await it.next();
+  t.true(sequenceEqual(<number[]>value, [1, 2]));
+  t.false(done);
+  await noNext(t, it);
+  t.end();
+});

--- a/spec/asynciterable/asyncifyerrback-spec.ts
+++ b/spec/asynciterable/asyncifyerrback-spec.ts
@@ -1,0 +1,53 @@
+import * as Ix from '../Ix';
+import * as test from 'tape-async';
+const { asyncifyErrback } = Ix.asynciterable;
+const { sequenceEqual } = Ix.iterable;
+import { hasNext, noNext } from '../asynciterablehelpers';
+
+test('AsyncIterable#asyncifyErrback single argument', async t => {
+  const callbackFn = (a: number, b: number, cb: Function) => {
+    cb(null, a + b);
+  };
+
+  const asyncFn = asyncifyErrback(callbackFn);
+  const xs = asyncFn(1, 2);
+
+  const it = xs[Symbol.asyncIterator]();
+  await hasNext(t, it, 3);
+  await noNext(t, it);
+  t.end();
+});
+
+test('AsyncIterable#asyncifyErrback with error', async t => {
+  const error = new Error();
+  const callbackFn = (a: number, b: number, cb: Function) => {
+    cb(error, a + b);
+  };
+
+  const asyncFn = asyncifyErrback(callbackFn);
+  const xs = asyncFn(1, 2);
+
+  const it = xs[Symbol.asyncIterator]();
+  try {
+    await it.next();
+  } catch (e) {
+    t.same(error, e);
+  }
+  t.end();
+});
+
+test('AsyncIterable#asyncifyErrback multiple arguments', async t => {
+  const callbackFn = (a: number, b: number, cb: Function) => {
+    cb(null, a, b);
+  };
+
+  const asyncFn = asyncifyErrback(callbackFn);
+  const xs = asyncFn(1, 2);
+
+  const it = xs[Symbol.asyncIterator]();
+  const { value, done } = await it.next();
+  t.true(sequenceEqual(<number[]>value, [1, 2]));
+  t.false(done);
+  await noNext(t, it);
+  t.end();
+});

--- a/src/Ix.ts
+++ b/src/Ix.ts
@@ -128,6 +128,8 @@ import './add/iterable-operators/union';
 import './add/iterable-operators/zip';
 
 // async iterable statics
+import './add/asynciterable/asyncify';
+import './add/asynciterable/asyncifyerrback';
 import './add/asynciterable/case';
 import './add/asynciterable/catch';
 import './add/asynciterable/concat';

--- a/src/add/asynciterable/asyncify.ts
+++ b/src/add/asynciterable/asyncify.ts
@@ -1,0 +1,8 @@
+import { AsyncIterableX } from '../../asynciterable';
+import { asyncify as asyncifyStatic } from '../../asynciterable/asyncify';
+
+AsyncIterableX.asyncify = asyncifyStatic;
+
+declare module '../../asynciterable' {
+  namespace AsyncIterableX { export let asyncify: typeof asyncifyStatic; }
+}

--- a/src/add/asynciterable/asyncifyerrback.ts
+++ b/src/add/asynciterable/asyncifyerrback.ts
@@ -1,0 +1,8 @@
+import { AsyncIterableX } from '../../asynciterable';
+import { asyncifyErrback as asyncifyErrbackStatic } from '../../asynciterable/asyncifyerrback';
+
+AsyncIterableX.asyncifyErrback = asyncifyErrbackStatic;
+
+declare module '../../asynciterable' {
+  namespace AsyncIterableX { export let asyncifyErrback: typeof asyncifyErrbackStatic; }
+}

--- a/src/asynciterable/__modules.ts
+++ b/src/asynciterable/__modules.ts
@@ -7,6 +7,8 @@ import { GroupedAsyncIterable } from './groupby';
 import { OrderedAsyncIterableX } from './orderby';
 import { OrderedAsyncIterableBaseX } from './orderby';
 
+import { asyncify } from './asyncify';
+import { asyncifyErrback } from './asyncifyerrback';
 import { average } from './average';
 import { buffer } from './buffer';
 import { _case } from './case';
@@ -122,6 +124,8 @@ export type OrderedAsyncIterableX<TKey, TSource> = OrderedAsyncIterableX<TKey, T
 export type OrderedAsyncIterableBaseX<TSource> = OrderedAsyncIterableBaseX<TSource>;
 
 export default {
+  asyncify,
+  asyncifyErrback,
   average,
   buffer,
   _case,

--- a/src/asynciterable/asyncify.ts
+++ b/src/asynciterable/asyncify.ts
@@ -1,0 +1,33 @@
+import { AsyncIterableX } from '../asynciterable';
+import { AsyncSink } from '../asyncsink';
+import { memoize } from './memoize';
+
+export function asyncify<TSource>(
+  func: Function
+): (...args: any[]) => AsyncIterableX<TSource> {
+  return function(...args: any[]) {
+
+    const sink = new AsyncSink<TSource>();
+
+    const handler = function(...innerArgs: any[]) {
+      sink.write(innerArgs.length === 1 ? innerArgs[0] : innerArgs);
+      sink.end();
+    };
+
+    try {
+      func(...args.concat(handler));
+    } catch (e) {
+      sink.error(e);
+    }
+
+    return memoize(
+      (async function*() {
+        for (let next; !(next = await sink.next()).done; ) {
+          yield next.value;
+        }
+
+        sink.end();
+      })()
+    );
+  };
+}

--- a/src/asynciterable/asyncify.ts
+++ b/src/asynciterable/asyncify.ts
@@ -18,6 +18,7 @@ export function asyncify<TSource>(
       func(...args.concat(handler));
     } catch (e) {
       sink.error(e);
+      sink.end();
     }
 
     return memoize(
@@ -25,8 +26,6 @@ export function asyncify<TSource>(
         for (let next; !(next = await sink.next()).done; ) {
           yield next.value;
         }
-
-        sink.end();
       })()
     );
   };

--- a/src/asynciterable/asyncifyerrback.ts
+++ b/src/asynciterable/asyncifyerrback.ts
@@ -1,0 +1,37 @@
+import { AsyncIterableX } from '../asynciterable';
+import { AsyncSink } from '../asyncsink';
+import { memoize } from './memoize';
+
+export function asyncifyErrback<TSource>(
+  func: Function
+): (...args: any[]) => AsyncIterableX<TSource> {
+  return function(...args: any[]) {
+
+    const sink = new AsyncSink<TSource>();
+
+    const handler = function(err: any, ...innerArgs: any[]) {
+      if (err) {
+        sink.error(err);
+      } else {
+        sink.write(innerArgs.length === 1 ? innerArgs[0] : innerArgs);
+        sink.end();
+      }
+    };
+
+    try {
+      func(...args.concat(handler));
+    } catch (e) {
+      sink.error(e);
+    }
+
+    return memoize(
+      (async function*() {
+        for (let next; !(next = await sink.next()).done; ) {
+          yield next.value;
+        }
+
+        sink.end();
+      })()
+    );
+  };
+}

--- a/src/asynciterable/asyncifyerrback.ts
+++ b/src/asynciterable/asyncifyerrback.ts
@@ -12,6 +12,7 @@ export function asyncifyErrback<TSource>(
     const handler = function(err: any, ...innerArgs: any[]) {
       if (err) {
         sink.error(err);
+        sink.end();
       } else {
         sink.write(innerArgs.length === 1 ? innerArgs[0] : innerArgs);
         sink.end();
@@ -22,6 +23,7 @@ export function asyncifyErrback<TSource>(
       func(...args.concat(handler));
     } catch (e) {
       sink.error(e);
+      sink.end();
     }
 
     return memoize(
@@ -29,8 +31,6 @@ export function asyncifyErrback<TSource>(
         for (let next; !(next = await sink.next()).done; ) {
           yield next.value;
         }
-
-        sink.end();
       })()
     );
   };

--- a/src/asynciterable/fromevent.ts
+++ b/src/asynciterable/fromevent.ts
@@ -1,3 +1,4 @@
+import { AsyncIterableX } from '../asynciterable';
 import { fromEventPattern } from './fromeventpattern';
 
 export type NodeEventEmitter = {
@@ -31,7 +32,7 @@ export function fromEvent<TSource>(
   obj: EventedTarget,
   type: string,
   options?: EventListenerOptions
-) {
+): AsyncIterableX<TSource> {
   if (isEventTarget(obj)) {
     const target = <EventTarget>obj;
     return fromEventPattern<TSource>(

--- a/src/asynciterable/fromeventpattern.ts
+++ b/src/asynciterable/fromeventpattern.ts
@@ -1,10 +1,11 @@
+import { AsyncIterableX } from '../asynciterable';
 import { AsyncSink } from '../asyncsink';
 import { memoize } from './memoize';
 
 export function fromEventPattern<TSource>(
   addHandler: (handler: (...args: any[]) => void) => void,
   removeHandler: (handler: (...args: any[]) => void) => void
-): AsyncIterable<TSource> {
+): AsyncIterableX<TSource> {
   const sink = new AsyncSink<TSource>();
   const handler = (e: TSource) => sink.write(e);
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!
-->

**Description:**

Adds the `asyncify` and `asyncifyErrback` to bind to callbacks to support regular callbacks and node style errBack callbacks to be bound to `AsyncIterable`.

**Related issue (if exists):**