### PR TITLE
fix(pipe): pipe() should always return IterableX<T>

### DIFF
--- a/src/asynciterable/pipe.ts
+++ b/src/asynciterable/pipe.ts
@@ -82,7 +82,7 @@ export function pipe<TSource, TResult>(
   ...operations: OperatorAsyncFunction<TSource, TResult>[]
 ): AsyncIterableX<TResult> {
   if (operations.length === 0) {
-    return source as any;
+    return source instanceof AsyncIterableX ? source : AsyncIterableX.from(source);
   }
 
   const piped = (input: AsyncIterable<TSource>): AsyncIterableX<TResult> => {

--- a/src/iterable/pipe.ts
+++ b/src/iterable/pipe.ts
@@ -79,7 +79,7 @@ export function pipe<TSource, TResult>(
   ...operations: OperatorFunction<TSource, TResult>[]
 ): IterableX<TResult> {
   if (operations.length === 0) {
-    return source as any;
+    return source instanceof IterableX ? source : IterableX.from(source);
   }
 
   const piped = (input: Iterable<TSource>): IterableX<TResult> => {


### PR DESCRIPTION
`pipe()`'s signature says it always takes `Iterable<T>` as the input and returns `IterableX<T>` as the result. But if `operations` is zero, it returned the input as the result. It's wrong.