### PR TITLE
feat(as): Add static `as` convenience methods to wrap values as Async/Iterables

### DIFF
--- a/spec/asynciterable/as-spec.ts
+++ b/spec/asynciterable/as-spec.ts
@@ -1,0 +1,147 @@
+import * as Ix from '../Ix';
+import * as test from 'tape-async';
+const { as } = Ix.AsyncIterable;
+const { map } = Ix.asynciterable;
+import { hasNext, noNext } from '../asynciterablehelpers';
+
+test('AsyncIterable#as from non-iterable', async t => {
+  const xs = {};
+  const res = as(xs);
+
+  const it = res[Symbol.asyncIterator]();
+  await hasNext(t, it, xs);
+  await noNext(t, it);
+  t.end();
+});
+
+test('AsyncIterable#as from string emits the string, not chars', async t => {
+  const x = 'foo';
+  const res = as(x);
+  const it = res[Symbol.asyncIterator]();
+  await hasNext(t, it, x);
+  await noNext(t, it);
+  t.end();
+});
+
+test('AsyncIterable#as from promise list', async t => {
+  const xs: Iterable<Promise<number>> = [
+    Promise.resolve(1),
+    Promise.resolve(2),
+    Promise.resolve(3)
+  ];
+  const res = as(xs);
+
+  const it = res[Symbol.asyncIterator]();
+  await hasNext(t, it, 1);
+  await hasNext(t, it, 2);
+  await hasNext(t, it, 3);
+  await noNext(t, it);
+  t.end();
+});
+
+async function* getData(): AsyncIterable<number> {
+  yield 1;
+  yield 2;
+  yield 3;
+}
+
+test('AsyncIterable#as from async generator', async t => {
+  const xs = getData();
+  const res = as(xs);
+
+  const it = res[Symbol.asyncIterator]();
+  await hasNext(t, it, 1);
+  await hasNext(t, it, 2);
+  await hasNext(t, it, 3);
+  await noNext(t, it);
+  t.end();
+});
+
+test('AsyncIterable#as from array/iterable', async t => {
+  const xs = [1, 2, 3];
+  const res = as(xs);
+
+  const it = res[Symbol.asyncIterator]();
+  await hasNext(t, it, 1);
+  await hasNext(t, it, 2);
+  await hasNext(t, it, 3);
+  await noNext(t, it);
+  t.end();
+});
+
+test('AsyncIterable#as from array/iterable with selector', async t => {
+  const xs = [1, 2, 3];
+  const res = map(as(xs), async (x, i) => x + i);
+
+  const it = res[Symbol.asyncIterator]();
+  await hasNext(t, it, 1);
+  await hasNext(t, it, 3);
+  await hasNext(t, it, 5);
+  await noNext(t, it);
+  t.end();
+});
+
+test('AsyncIterable#as from async generator with selector', async t => {
+  const xs = getData();
+  const res = map(as(xs), async (x, i) => x + i);
+
+  const it = res[Symbol.asyncIterator]();
+  await hasNext(t, it, 1);
+  await hasNext(t, it, 3);
+  await hasNext(t, it, 5);
+  await noNext(t, it);
+  t.end();
+});
+
+test('AsyncIterable#as from empty array/iterable', async t => {
+  const xs: number[] = [];
+  const res = as(xs);
+
+  const it = res[Symbol.asyncIterator]();
+  await noNext(t, it);
+  t.end();
+});
+
+test('AsyncIterable#as from array-like', async t => {
+  const xs = { length: 3 };
+  const res = as(xs);
+
+  const it = res[Symbol.asyncIterator]();
+  await hasNext(t, it, undefined);
+  await hasNext(t, it, undefined);
+  await hasNext(t, it, undefined);
+  await noNext(t, it);
+  t.end();
+});
+
+test('AsyncIterable#as from array-like with selector', async t => {
+  const xs = { length: 3 };
+  const res = map(as(xs), (x, i) => i);
+
+  const it = res[Symbol.asyncIterator]();
+  await hasNext(t, it, 0);
+  await hasNext(t, it, 1);
+  await hasNext(t, it, 2);
+  await noNext(t, it);
+  t.end();
+});
+
+test('AsyncIterable#as from promise', async t => {
+  const xs = Promise.resolve(42);
+  const res = as(xs);
+
+  const it = res[Symbol.asyncIterator]();
+  await hasNext(t, it, 42);
+  await noNext(t, it);
+  t.end();
+});
+
+test('AsyncIterable#as from promise with selector', async t => {
+  const xs = Promise.resolve(42);
+  const res = map(as(xs), (x, i) => x + i);
+
+  const it = res[Symbol.asyncIterator]();
+  await hasNext(t, it, 42);
+  await noNext(t, it);
+  t.end();
+});

--- a/spec/asynciterable/from-spec.ts
+++ b/spec/asynciterable/from-spec.ts
@@ -127,24 +127,14 @@ test('AsyncIterable#from from promise with selector', async t => {
   t.end();
 });
 
-test('AsyncIterable#from from non-iterable', async t => {
-  const xs = {};
-  const res = from(xs);
-
-  const it = res[Symbol.asyncIterator]();
-  await hasNext(t, it, xs);
-  await noNext(t, it);
-  t.end();
-});
-
-test('AsyncIterable#from from array-like with selector', async t => {
-  const xs = {};
-  const res = from(xs, (x, i) => [x, i]);
-
-  const it = res[Symbol.asyncIterator]();
-  await hasNext(t, it, [xs, 0]);
-  await noNext(t, it);
-  t.end();
+test('AsyncIterable#from from with non-iterable throws', t => {
+  let error = false;
+  try {
+    from({} as any);
+  } catch (e) {
+    error = true;
+  }
+  error ? t.end() : t.fail('expected from to throw');
 });
 
 interface Observer<T> {

--- a/spec/asynciterablehelpers.ts
+++ b/spec/asynciterablehelpers.ts
@@ -41,8 +41,6 @@ export function testOperator<Op>(op: Op) {
     test(`(proto) ${message}`, async t => await (testFn as any)(t, fnNames.map(wrapProto)));
     if (pipeFns.every(xs => typeof xs === 'function')) {
       test(`(pipe) ${message}`, async t => await (testFn as any)(t, pipeFns.map(wrapPipe)));
-      // } else {
-      //   console.log(`AsyncIterable missing a pipe fn in [${internalNames.join(`, `)}], skipping...`);
     }
   };
 }
@@ -64,5 +62,5 @@ function wrapPipe(fn: any) {
 }
 
 function cast(source: any): any {
-  return source instanceof Ix.AsyncIterable ? source : Ix.AsyncIterable.from(source);
+  return source instanceof Ix.AsyncIterable ? source : Ix.AsyncIterable.as(source);
 }

--- a/spec/iterable/as-spec.ts
+++ b/spec/iterable/as-spec.ts
@@ -1,11 +1,12 @@
 import * as Ix from '../Ix';
 import * as test from 'tape-async';
-const { from } = Ix.Iterable;
+const { as } = Ix.Iterable;
+const { map } = Ix.iterable;
 import { hasNext, noNext } from '../iterablehelpers';
 
-test('Iterable#from from array/iterable', t => {
+test('Iterable#as from array/iterable', t => {
   const xs = [1, 2, 3];
-  const res = from(xs);
+  const res = as(xs);
 
   const it = res[Symbol.iterator]();
   hasNext(t, it, 1);
@@ -15,9 +16,9 @@ test('Iterable#from from array/iterable', t => {
   t.end();
 });
 
-test('Iterable#from from array/iterable with selector', t => {
+test('Iterable#as from array/iterable with selector', t => {
   const xs = [1, 2, 3];
-  const res = from(xs, (x, i) => x + i);
+  const res = map(as(xs), (x, i) => x + i);
 
   const it = res[Symbol.iterator]();
   hasNext(t, it, 1);
@@ -27,18 +28,18 @@ test('Iterable#from from array/iterable with selector', t => {
   t.end();
 });
 
-test('Iterable#from from empty array/iterable', t => {
+test('Iterable#as from empty array/iterable', t => {
   const xs: number[] = [];
-  const res = from(xs);
+  const res = as(xs);
 
   const it = res[Symbol.iterator]();
   noNext(t, it);
   t.end();
 });
 
-test('Iterable#from from array-like', t => {
+test('Iterable#as from array-like', t => {
   const xs = { length: 3 };
-  const res = from(xs);
+  const res = as(xs);
 
   const it = res[Symbol.iterator]();
   hasNext(t, it, undefined);
@@ -48,9 +49,9 @@ test('Iterable#from from array-like', t => {
   t.end();
 });
 
-test('Iterable#from from array-like with selector', t => {
+test('Iterable#as from array-like with selector', t => {
   const xs = { length: 3 };
-  const res = from(xs, (x, i) => i);
+  const res = map(as(xs), (x, i) => i);
 
   const it = res[Symbol.iterator]();
   hasNext(t, it, 0);
@@ -60,12 +61,22 @@ test('Iterable#from from array-like with selector', t => {
   t.end();
 });
 
-test('Iterable#from from with non-iterable throws', t => {
-  let error = false;
-  try {
-    from({} as any);
-  } catch (e) {
-    error = true;
-  }
-  error ? t.end() : t.fail('expected from to throw');
+test('Iterable#as from non-iterable', t => {
+  const xs = {};
+  const res = as(xs);
+
+  const it = res[Symbol.iterator]();
+  hasNext(t, it, xs);
+  noNext(t, it);
+  t.end();
+});
+
+test('Iterable#as from non-iterable with selector', t => {
+  const xs = {};
+  const res = map(as(xs), (x, i) => [x, i]);
+
+  const it = res[Symbol.iterator]();
+  hasNext(t, it, [xs, 0]);
+  noNext(t, it);
+  t.end();
 });

--- a/spec/iterablehelpers.ts
+++ b/spec/iterablehelpers.ts
@@ -31,8 +31,6 @@ export function testOperator<Op>(op: Op) {
     test(`(proto) ${message}`, t => (testFn as any)(t, fnNames.map(wrapProto)));
     if (pipeFns.every(xs => typeof xs === 'function')) {
       test(`(pipe) ${message}`, t => (testFn as any)(t, pipeFns.map(wrapPipe)));
-      // } else {
-      //   console.log(`Iterable missing a pipe fn in [${internalNames.join(`, `)}], skipping...`);
     }
   };
 }
@@ -54,5 +52,5 @@ function wrapPipe(fn: any) {
 }
 
 function cast(source: any): any {
-  return source instanceof Ix.Iterable ? source : Ix.Iterable.from(source);
+  return source instanceof Ix.Iterable ? source : Ix.Iterable.as(source);
 }

--- a/src/iterable/iterablex.ts
+++ b/src/iterable/iterablex.ts
@@ -30,8 +30,27 @@ export abstract class IterableX<T> implements Iterable<T> {
     return piped(this);
   }
 
+  static as(source: string): IterableX<string>;
+  static as<T>(source: Iterable<T>): IterableX<T>;
+  static as<T>(source: ArrayLike<T>): IterableX<T>;
+  static as<T>(source: T): IterableX<T>;
+  static as(source: any) {
+    /* tslint:disable */
+    if (typeof source === 'string') {
+      return new OfIterable([source]);
+    }
+    if (isIterable(source)) {
+      return new FromIterable(source, identity);
+    }
+    if (isArrayLike(source)) {
+      return new FromIterable(source, identity);
+    }
+    return new OfIterable([source]);
+    /* tslint:enable */
+  }
+
   static from<TSource, TResult = TSource>(
-    source: Iterable<TSource> | ArrayLike<TSource> | TSource,
+    source: Iterable<TSource> | ArrayLike<TSource>,
     selector: (value: TSource, index: number) => TResult = identity,
     thisArg?: any
   ): IterableX<TResult> {
@@ -43,7 +62,7 @@ export abstract class IterableX<T> implements Iterable<T> {
     if (isArrayLike(source)) {
       return new FromIterable<TSource, TResult>(source, fn);
     }
-    return new FromIterable<TSource, TResult>(new OfIterable<TSource>([source as TSource]), fn);
+    throw new TypeError('Input type not supported');
     /* tslint:enable */
   }
 


### PR DESCRIPTION
This PR introduces `Iterable.as()` and `AsyncIterable.as()` convenience methods to wrap values as Iterables/AsyncIterables. `as` is a hybrid of `from` and `of`, except that when handed a string, it doesn't iterate the chars from the string (like `from` would), and instead works like `of`. This PR also reverts #117, so that `Iterable.from` behaves like the built-in `Array.from` again.