### PR TITLE
fix(typings): Fix optional predicate typings for user-defined typeguard predicates

### DIFF
--- a/src/add/asynciterable-operators/first.ts
+++ b/src/add/asynciterable-operators/first.ts
@@ -7,7 +7,7 @@ import { first } from '../../asynciterable/first';
 
 export function firstProto<T, S extends T>(
   this: AsyncIterableX<T>,
-  predicate?: (value: T, index: number) => value is S
+  predicate: (value: T, index: number) => value is S
 ): Promise<S | undefined>;
 export function firstProto<T>(
   this: AsyncIterableX<T>,

--- a/src/add/asynciterable-operators/last.ts
+++ b/src/add/asynciterable-operators/last.ts
@@ -7,7 +7,7 @@ import { last } from '../../asynciterable/last';
 
 export function lastProto<T, S extends T>(
   this: AsyncIterableX<T>,
-  predicate?: (value: T, index: number) => value is S
+  predicate: (value: T, index: number) => value is S
 ): Promise<S | undefined>;
 export function lastProto<T>(
   this: AsyncIterableX<T>,

--- a/src/add/asynciterable-operators/single.ts
+++ b/src/add/asynciterable-operators/single.ts
@@ -7,7 +7,7 @@ import { single } from '../../asynciterable/single';
 
 export function singleProto<T, S extends T>(
   this: AsyncIterableX<T>,
-  predicate?: (value: T, index: number) => value is S
+  predicate: (value: T, index: number) => value is S
 ): Promise<S | undefined>;
 export function singleProto<T>(
   this: AsyncIterableX<T>,

--- a/src/add/iterable-operators/first.ts
+++ b/src/add/iterable-operators/first.ts
@@ -7,7 +7,7 @@ import { first } from '../../iterable/first';
 
 export function firstProto<T, S extends T>(
   this: IterableX<T>,
-  predicate?: (value: T, index: number) => value is S
+  predicate: (value: T, index: number) => value is S
 ): S | undefined;
 export function firstProto<T>(
   this: IterableX<T>,

--- a/src/add/iterable-operators/last.ts
+++ b/src/add/iterable-operators/last.ts
@@ -6,7 +6,7 @@ import { last } from '../../iterable/last';
  */
 export function lastProto<T, S extends T>(
   this: IterableX<T>,
-  predicate?: (value: T, index: number) => value is S
+  predicate: (value: T, index: number) => value is S
 ): S | undefined;
 export function lastProto<T>(
   this: IterableX<T>,

--- a/src/add/iterable-operators/single.ts
+++ b/src/add/iterable-operators/single.ts
@@ -6,7 +6,7 @@ import { single } from '../../iterable/single';
  */
 export function singleProto<T, S extends T>(
   this: IterableX<T>,
-  predicate?: (value: T, index: number) => value is S
+  predicate: (value: T, index: number) => value is S
 ): S | undefined;
 export function singleProto<T>(
   this: IterableX<T>,

--- a/src/asynciterable/first.ts
+++ b/src/asynciterable/first.ts
@@ -1,6 +1,6 @@
 export async function first<T, S extends T>(
   source: AsyncIterable<T>,
-  predicate?: (value: T, index: number) => value is S
+  predicate: (value: T, index: number) => value is S
 ): Promise<S | undefined>;
 export async function first<T>(
   source: AsyncIterable<T>,

--- a/src/asynciterable/last.ts
+++ b/src/asynciterable/last.ts
@@ -1,6 +1,6 @@
 export async function last<T, S extends T>(
   source: AsyncIterable<T>,
-  predicate?: (value: T, index: number) => value is S
+  predicate: (value: T, index: number) => value is S
 ): Promise<S | undefined>;
 export async function last<T>(
   source: AsyncIterable<T>,

--- a/src/asynciterable/single.ts
+++ b/src/asynciterable/single.ts
@@ -1,6 +1,6 @@
 export async function single<T, S extends T>(
   source: AsyncIterable<T>,
-  predicate?: (value: T, index: number) => value is S
+  predicate: (value: T, index: number) => value is S
 ): Promise<S | undefined>;
 export async function single<T>(
   source: AsyncIterable<T>,

--- a/src/iterable/first.ts
+++ b/src/iterable/first.ts
@@ -9,7 +9,7 @@
  */
 export function first<T, S extends T>(
   source: Iterable<T>,
-  predicate?: (value: T, index: number) => value is S
+  predicate: (value: T, index: number) => value is S
 ): S | undefined;
 export function first<T>(
   source: Iterable<T>,

--- a/src/iterable/last.ts
+++ b/src/iterable/last.ts
@@ -1,6 +1,6 @@
 export function last<T, S extends T>(
   source: Iterable<T>,
-  predicate?: (value: T, index: number) => value is S
+  predicate: (value: T, index: number) => value is S
 ): S | undefined;
 export function last<T>(
   source: Iterable<T>,

--- a/src/iterable/single.ts
+++ b/src/iterable/single.ts
@@ -1,6 +1,6 @@
 export function single<T, S extends T>(
   source: Iterable<T>,
-  predicate?: (value: T, index: number) => value is S
+  predicate: (value: T, index: number) => value is S
 ): S | undefined;
 export function single<T>(
   source: Iterable<T>,


### PR DESCRIPTION
Since they're listed first, the user-defined typeguard types are taking precedence over the optional-predicate forms of the value-or-Promise-returning operators when no predicate is supplied. Since they downcast to a subtype of the input type, this behavior can cause the types to flow incorrectly.

Intellisense currently:
<img width="812" alt="screen shot 2017-11-26 at 5 50 49 am" src="https://user-images.githubusercontent.com/178183/33240665-b43faa14-d26e-11e7-8124-fa9c6d6b6d67.png">

Intellisense with this PR applied:
<img width="813" alt="screen shot 2017-11-26 at 5 52 59 am" src="https://user-images.githubusercontent.com/178183/33240674-c402c2ce-d26e-11e7-9653-19749f912524.png">
