### PR TITLE
Fix TS errors when used in projects with less strict compiler flags than ours

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -231,7 +231,7 @@ const compileTypescript = ((cache) => memoizeTask(cache, function typescript(tar
   const tsProject = ts.createProject(path.join(`tsconfig`, tsconfigFile));
   const { stream: { js, dts } } = Observable.fromStream(
     tsProject.src(), sourcemaps.init(),
-    tsProject(ts.reporter.fullReporter(true))
+    tsProject(ts.reporter.defaultReporter())
   );
   const writeDTypes = Observable.fromStream(dts, gulp.dest(out));
   const writeJS = Observable.fromStream(js, sourcemaps.write(), gulp.dest(out));

--- a/src/asynciterable/distinct.ts
+++ b/src/asynciterable/distinct.ts
@@ -20,7 +20,7 @@ export class DistinctAsyncIterable<TSource, TKey> extends AsyncIterableX<TSource
   }
 
   async *[Symbol.asyncIterator]() {
-    let set = [];
+    let set = [] as TKey[];
 
     for await (let item of <AsyncIterable<TSource>>this._source) {
       let key = await this._keySelector(item);

--- a/src/asynciterable/except.ts
+++ b/src/asynciterable/except.ts
@@ -19,7 +19,7 @@ export class ExceptAsyncIterable<TSource> extends AsyncIterableX<TSource> {
   }
 
   async *[Symbol.asyncIterator]() {
-    let map = [];
+    let map = [] as TSource[];
     for await (let secondItem of this._second) {
       map.push(secondItem);
     }

--- a/src/asynciterable/flatten.ts
+++ b/src/asynciterable/flatten.ts
@@ -16,7 +16,7 @@ export class FlattenAsyncIterable<TSource> extends AsyncIterableX<TSource> {
       for await (let item of source) {
         yield item;
       }
-      return;
+      return undefined;
     }
     for await (let item of source) {
       if (isAsyncIterable(item)) {

--- a/src/asynciterable/intersect.ts
+++ b/src/asynciterable/intersect.ts
@@ -32,7 +32,7 @@ export class IntersectAsyncIterable<TSource> extends AsyncIterableX<TSource> {
   }
 
   async *[Symbol.asyncIterator]() {
-    let map = [];
+    let map = [] as TSource[];
     for await (let secondItem of this._second) {
       map.push(secondItem);
     }

--- a/src/asynciterable/reverse.ts
+++ b/src/asynciterable/reverse.ts
@@ -9,7 +9,7 @@ export class ReverseAsyncIterable<TSource> extends AsyncIterableX<TSource> {
   }
 
   async *[Symbol.asyncIterator]() {
-    let results = [];
+    let results = [] as TSource[];
     for await (let item of this._source) {
       results.unshift(item);
     }

--- a/src/asynciterable/skiplast.ts
+++ b/src/asynciterable/skiplast.ts
@@ -11,7 +11,7 @@ export class SkipLastAsyncIterable<TSource> extends AsyncIterableX<TSource> {
   }
 
   async *[Symbol.asyncIterator]() {
-    let q = [];
+    let q = [] as TSource[];
     for await (let item of this._source) {
       q.push(item);
       if (q.length > this._count) {

--- a/src/asynciterable/takelast.ts
+++ b/src/asynciterable/takelast.ts
@@ -11,20 +11,18 @@ export class TakeLastAsyncIterable<TSource> extends AsyncIterableX<TSource> {
   }
 
   async *[Symbol.asyncIterator]() {
-    if (this._count === 0) {
-      return;
-    }
-
-    let q = [];
-    for await (let item of this._source) {
-      if (q.length >= this._count) {
-        q.shift();
+    if (this._count > 0) {
+      let q = [] as TSource[];
+      for await (let item of this._source) {
+        if (q.length >= this._count) {
+          q.shift();
+        }
+        q.push(item);
       }
-      q.push(item);
-    }
 
-    while (q.length > 0) {
-      yield q.shift()!;
+      while (q.length > 0) {
+        yield q.shift()!;
+      }
     }
   }
 }

--- a/src/asynciterable/toarray.ts
+++ b/src/asynciterable/toarray.ts
@@ -1,5 +1,5 @@
 export async function toArray<TSource>(source: AsyncIterable<TSource>): Promise<TSource[]> {
-  let results = [];
+  let results = [] as TSource[];
   for await (let item of source) {
     results.push(item);
   }

--- a/src/asynciterable/union.ts
+++ b/src/asynciterable/union.ts
@@ -19,7 +19,7 @@ export class UnionAsyncIterable<TSource> extends AsyncIterableX<TSource> {
   }
 
   async *[Symbol.asyncIterator]() {
-    let map = [];
+    let map = [] as TSource[];
     for await (let lItem of this._left) {
       if ((await arrayIndexOfAsync(map, lItem, this._comparer)) === -1) {
         map.push(lItem);

--- a/src/asynciterable/zip.ts
+++ b/src/asynciterable/zip.ts
@@ -15,7 +15,7 @@ export class ZipAsyncIterable<TSource, TResult> extends AsyncIterableX<TResult> 
     this._fn = fn;
   }
 
-  async *[Symbol.asyncIterator]() {
+  async *[Symbol.asyncIterator](): AsyncIterableIterator<TResult> {
     const fn = this._fn;
     const sourcesLength = this._sources.length;
     const its = this._sources.map(x => x[Symbol.asyncIterator]());
@@ -25,7 +25,7 @@ export class ZipAsyncIterable<TSource, TResult> extends AsyncIterableX<TResult> 
         const result = await its[i].next();
         if (result.done) {
           await Promise.all(its.map(returnAsyncIterator));
-          return;
+          return undefined;
         }
         values[i] = result.value;
       }

--- a/src/iterable/distinct.ts
+++ b/src/iterable/distinct.ts
@@ -20,7 +20,7 @@ export class DistinctIterable<TSource, TKey> extends IterableX<TSource> {
   }
 
   *[Symbol.iterator]() {
-    let set = [];
+    let set = [] as TKey[];
 
     for (let item of this._source) {
       let key = this._keySelector(item);

--- a/src/iterable/except.ts
+++ b/src/iterable/except.ts
@@ -19,7 +19,7 @@ export class ExceptIterable<TSource> extends IterableX<TSource> {
   }
 
   *[Symbol.iterator]() {
-    let map = [];
+    let map = [] as TSource[];
     for (let secondItem of this._second) {
       map.push(secondItem);
     }

--- a/src/iterable/flatten.ts
+++ b/src/iterable/flatten.ts
@@ -16,7 +16,7 @@ export class FlattenIterable<TSource> extends IterableX<TSource> {
       for (let item of source) {
         yield item;
       }
-      return;
+      return undefined;
     }
     for (let item of source) {
       if (isIterable(item)) {

--- a/src/iterable/intersect.ts
+++ b/src/iterable/intersect.ts
@@ -28,7 +28,7 @@ export class IntersectIterable<TSource> extends IterableX<TSource> {
   }
 
   *[Symbol.iterator]() {
-    let map = [];
+    let map = [] as TSource[];
     for (let secondItem of this._second) {
       map.push(secondItem);
     }

--- a/src/iterable/reverse.ts
+++ b/src/iterable/reverse.ts
@@ -9,7 +9,7 @@ export class ReverseIterable<TSource> extends IterableX<TSource> {
   }
 
   *[Symbol.iterator]() {
-    let results = [];
+    let results = [] as TSource[];
     for (let item of this._source) {
       results.unshift(item);
     }

--- a/src/iterable/skiplast.ts
+++ b/src/iterable/skiplast.ts
@@ -11,7 +11,7 @@ export class SkipLastIterable<TSource> extends IterableX<TSource> {
   }
 
   *[Symbol.iterator]() {
-    let q = [];
+    let q = [] as TSource[];
     for (let item of this._source) {
       q.push(item);
       if (q.length > this._count) {

--- a/src/iterable/takelast.ts
+++ b/src/iterable/takelast.ts
@@ -11,20 +11,18 @@ export class TakeLastIterable<TSource> extends IterableX<TSource> {
   }
 
   *[Symbol.iterator]() {
-    if (this._count === 0) {
-      return;
-    }
-
-    let q = [];
-    for (let item of this._source) {
-      if (q.length >= this._count) {
-        q.shift();
+    if (this._count > 0) {
+      let q = [] as TSource[];
+      for (let item of this._source) {
+        if (q.length >= this._count) {
+          q.shift();
+        }
+        q.push(item);
       }
-      q.push(item);
-    }
 
-    while (q.length > 0) {
-      yield q.shift()!;
+      while (q.length > 0) {
+        yield q.shift()!;
+      }
     }
   }
 }

--- a/src/iterable/toarray.ts
+++ b/src/iterable/toarray.ts
@@ -1,5 +1,5 @@
 export function toArray<TSource>(source: Iterable<TSource>): TSource[] {
-  let results = [];
+  let results = [] as TSource[];
   for (let item of source) {
     results.push(item);
   }

--- a/src/iterable/union.ts
+++ b/src/iterable/union.ts
@@ -19,7 +19,7 @@ export class UnionIterable<TSource> extends IterableX<TSource> {
   }
 
   *[Symbol.iterator]() {
-    let map = [];
+    let map = [] as TSource[];
     for (let lItem of this._left) {
       if (arrayIndexOf(map, lItem, this._comparer) === -1) {
         map.push(lItem);

--- a/src/iterable/zip.ts
+++ b/src/iterable/zip.ts
@@ -11,7 +11,7 @@ export class ZipIterable<TSource, TResult> extends IterableX<TResult> {
     this._sources = sources;
     this._fn = fn;
   }
-  *[Symbol.iterator]() {
+  *[Symbol.iterator](): IterableIterator<TResult> {
     const fn = this._fn;
     const sourcesLength = this._sources.length;
     const its = this._sources.map(x => x[Symbol.iterator]());
@@ -21,7 +21,7 @@ export class ZipIterable<TSource, TResult> extends IterableX<TResult> {
         const result = its[index].next();
         if (result.done) {
           its.forEach(returnIterator);
-          return;
+          return undefined;
         }
         values[index] = result.value;
       }


### PR DESCRIPTION
This works around (what I believe are) [typescript compiler bugs](https://github.com/Microsoft/TypeScript/issues/20299) introduced when projects are compiled without all the `--strict` mode flags on, specifically `--noImplicitAny` and `--strictNullChecks`.

We don't see these errors because we run with all the strict mode flags, enabling TS to infer more than it can when not in strict mode.

Fixes these errors caused by `strictNullChecks` being `false`:
```
ix/asynciterable/flatten.ts(19,7): error TS7030: Not all code paths return a value.
ix/asynciterable/takelast.ts(15,7): error TS7030: Not all code paths return a value.
ix/asynciterable/zip.ts(28,11): error TS7030: Not all code paths return a value.
ix/iterable/flatten.ts(19,7): error TS7030: Not all code paths return a value.
ix/iterable/takelast.ts(15,7): error TS7030: Not all code paths return a value.
ix/iterable/zip.ts(24,11): error TS7030: Not all code paths return a value.
```

Fixes these errors caused by `noImplicitAny` being `false`:
```
ix/asynciterable/distinct.ts(28,18): error TS2345: Argument of type 'TKey' is not assignable to parameter of type 'never'.
ix/asynciterable/except.ts(24,16): error TS2345: Argument of type 'TSource' is not assignable to parameter of type 'never'.
ix/asynciterable/except.ts(29,18): error TS2345: Argument of type 'TSource' is not assignable to parameter of type 'never'.
ix/asynciterable/intersect.ts(37,16): error TS2345: Argument of type 'TSource' is not assignable to parameter of type 'never'.
ix/asynciterable/reverse.ts(14,23): error TS2345: Argument of type 'TSource' is not assignable to parameter of type 'never'.
ix/asynciterable/skiplast.ts(16,14): error TS2345: Argument of type 'TSource' is not assignable to parameter of type 'never'.
ix/asynciterable/takelast.ts(23,14): error TS2345: Argument of type 'TSource' is not assignable to parameter of type 'never'.
ix/asynciterable/toarray.ts(4,18): error TS2345: Argument of type 'TSource' is not assignable to parameter of type 'never'.
ix/asynciterable/union.ts(25,18): error TS2345: Argument of type 'TSource' is not assignable to parameter of type 'never'.
ix/asynciterable/union.ts(32,18): error TS2345: Argument of type 'TSource' is not assignable to parameter of type 'never'.
ix/iterable/distinct.ts(28,18): error TS2345: Argument of type 'TKey' is not assignable to parameter of type 'never'.
ix/iterable/except.ts(24,16): error TS2345: Argument of type 'TSource' is not assignable to parameter of type 'never'.
ix/iterable/except.ts(29,18): error TS2345: Argument of type 'TSource' is not assignable to parameter of type 'never'.
ix/iterable/intersect.ts(33,16): error TS2345: Argument of type 'TSource' is not assignable to parameter of type 'never'.
ix/iterable/reverse.ts(14,23): error TS2345: Argument of type 'TSource' is not assignable to parameter of type 'never'.
ix/iterable/skiplast.ts(16,14): error TS2345: Argument of type 'TSource' is not assignable to parameter of type 'never'.
ix/iterable/takelast.ts(23,14): error TS2345: Argument of type 'TSource' is not assignable to parameter of type 'never'.
ix/iterable/toarray.ts(4,18): error TS2345: Argument of type 'TSource' is not assignable to parameter of type 'never'.
ix/iterable/union.ts(25,18): error TS2345: Argument of type 'TSource' is not assignable to parameter of type 'never'.
ix/iterable/union.ts(32,18): error TS2345: Argument of type 'TSource' is not assignable to parameter of type 'never'.
```