### PR TITLE
fix(compile): adding some missing exports to deal with typescript 2.7.x compat issue

### DIFF
--- a/src/asynciterable/concat.ts
+++ b/src/asynciterable/concat.ts
@@ -55,6 +55,7 @@ export function concat<T, T2, T3, T4, T5, T6>(
   v5: AsyncIterable<T5>,
   v6: AsyncIterable<T6>
 ): AsyncIterable<T | T2 | T3 | T4 | T5 | T6>;
+export function concat<T>(source: AsyncIterable<T>, ...args: AsyncIterable<T>[]): AsyncIterableX<T>;
 /* tslint:enable:max-line-length */
 
 export function concat<T>(

--- a/src/asynciterable/merge.ts
+++ b/src/asynciterable/merge.ts
@@ -75,6 +75,7 @@ export function merge<T, T2, T3, T4, T5, T6>(
   v5: AsyncIterable<T5>,
   v6: AsyncIterable<T6>
 ): AsyncIterable<T | T2 | T3 | T4 | T5 | T6>;
+export function merge<T>(source: AsyncIterable<T>, ...args: AsyncIterable<T>[]): AsyncIterableX<T>;
 /* tslint:enable:max-line-length */
 
 export function merge<T>(source: AsyncIterable<T>, ...args: AsyncIterable<T>[]): AsyncIterableX<T> {

--- a/src/iterable/concat.ts
+++ b/src/iterable/concat.ts
@@ -44,6 +44,7 @@ export function concat<T, T2, T3, T4, T5, T6>(
   v5: Iterable<T5>,
   v6: Iterable<T6>
 ): Iterable<T | T2 | T3 | T4 | T5 | T6>;
+export function concat<T>(source: Iterable<T>, ...args: Iterable<T>[]): IterableX<T>;
 /* tslint:enable:max-line-length */
 
 export function concat<T>(source: Iterable<T>, ...args: Iterable<T>[]): IterableX<T> {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!
-->

**Description:**

Adding these three lines no longer produces the 2.7 compile errors (as seen below).

```
ERROR in [at-loader] ./node_modules/ix/add/asynciterable-operators/concat.ts:63:10
    TS2556: Expected 1-6 arguments, but got 1 or more.

ERROR in [at-loader] ./node_modules/ix/add/asynciterable-operators/merge.ts:63:10
    TS2556: Expected 1-6 arguments, but got 1 or more.

ERROR in [at-loader] ./node_modules/ix/add/iterable-operators/concat.ts:54:10
    TS2556: Expected 1-6 arguments, but got 1 or more.
```

**Related issue (if exists):**

resolves #214