### PR TITLE
Add `AsyncIterableX#batch()`

### DIFF
--- a/spec/asynciterable-operators/batch-spec.ts
+++ b/spec/asynciterable-operators/batch-spec.ts
@@ -1,0 +1,79 @@
+import * as Ix from '../Ix';
+import { testOperator } from '../asynciterablehelpers';
+const test = testOperator([Ix.asynciterable.batch]);
+
+const delay = (ms = 0) => new Promise(resolve => setTimeout(resolve, ms));
+
+test('AsyncIterable#batch basic', async (t, [batch]) => {
+  const sink = new Ix.AsyncSink<number>();
+
+  const it = batch(sink)[Symbol.asyncIterator]();
+
+  sink.write(1);
+  sink.write(2);
+
+  await delay();
+  t.deepEqual(await it.next(), { done: false, value: [1, 2] });
+
+  setTimeout(() => sink.write(3), 50);
+
+  t.deepEqual(await it.next(), { done: false, value: [3] });
+
+  sink.write(4);
+  sink.write(5);
+  sink.end();
+
+  await delay();
+  t.deepEqual(await it.next(), {
+    done: false,
+    value: [4, 5]
+  });
+  t.deepEqual(await it.next(), {
+    done: true
+  });
+
+  t.end();
+});
+
+test('done while waiting', async (t, [batch]) => {
+  const sink = new Ix.AsyncSink<number>();
+
+  const it = batch(sink)[Symbol.asyncIterator]();
+
+  sink.write(1);
+  sink.write(2);
+
+  await delay();
+  t.deepEqual(await it.next(), { done: false, value: [1, 2] });
+
+  setTimeout(() => sink.end(), 50);
+
+  t.deepEqual(await it.next(), { done: true });
+
+  t.end();
+});
+
+test('canceled', async (t, [batch]) => {
+  let canceled = false;
+
+  async function* generate() {
+    try {
+      for (let i = 0; ; i++) {
+        await delay(100);
+        yield i;
+      }
+    } finally {
+      canceled = true;
+    }
+  }
+
+  const it = batch(generate())[Symbol.asyncIterator]();
+
+  await delay(150);
+  t.deepEqual(await it.next(), { done: false, value: [0] });
+
+  t.deepEqual(await it.return!(), { done: true });
+  t.true(canceled);
+
+  t.end();
+});

--- a/src/Ix.ts
+++ b/src/Ix.ts
@@ -147,6 +147,7 @@ import './add/asynciterable/zip';
 
 // async iterable operators
 import './add/asynciterable-operators/average';
+import './add/asynciterable-operators/batch';
 import './add/asynciterable-operators/buffer';
 import './add/asynciterable-operators/catch';
 import './add/asynciterable-operators/catchwith';

--- a/src/add/asynciterable-operators/batch.ts
+++ b/src/add/asynciterable-operators/batch.ts
@@ -1,0 +1,17 @@
+import { AsyncIterableX } from '../../asynciterable/asynciterablex';
+import { batch } from '../../asynciterable/batch';
+
+/**
+ * @ignore
+ */
+export function batchProto<T>(this: AsyncIterableX<T>): AsyncIterableX<T[]> {
+  return batch<T>(this);
+}
+
+AsyncIterableX.prototype.batch = batchProto;
+
+declare module '../../asynciterable/asynciterablex' {
+  interface AsyncIterableX<T> {
+    batch: typeof batchProto;
+  }
+}

--- a/src/asynciterable/batch.ts
+++ b/src/asynciterable/batch.ts
@@ -1,0 +1,112 @@
+import { AsyncIterableX } from './asynciterablex';
+
+interface AsyncResolver<T> {
+  resolve: (value?: T | PromiseLike<T> | undefined) => void;
+  reject: (reason?: any) => void;
+}
+
+interface WaitingState<T> {
+  type: 'waiting';
+  resolver: AsyncResolver<IteratorResult<T[]>>;
+}
+interface BatchingState<T> {
+  type: 'batching';
+  values: T[];
+}
+
+type State<T> = WaitingState<T> | BatchingState<T>;
+
+function assertNever(value: never): never {
+  throw new Error(`Unhandled discriminated union member ${value}`);
+}
+
+class BatchAsyncIterable<TSource> extends AsyncIterableX<TSource[]> {
+  private _source: AsyncIterable<TSource>;
+
+  constructor(source: AsyncIterable<TSource>) {
+    super();
+    this._source = source;
+  }
+
+  [Symbol.asyncIterator]() {
+    const it = this._source[Symbol.asyncIterator]();
+
+    let state: State<TSource> = { type: 'batching', values: [] };
+    let ended: null | Promise<IteratorResult<TSource[]>> = null;
+
+    function consumeNext() {
+      it.next().then(
+        res => {
+          if (res.done) {
+            ended = Promise.resolve({ done: true } as IteratorResult<TSource[]>);
+
+            if (state.type === 'waiting') {
+              state.resolver.resolve(ended);
+            }
+          } else {
+            if (state.type === 'waiting') {
+              const { resolve } = state.resolver;
+              state = { type: 'batching', values: [] };
+              resolve({ done: res.done, value: [res.value] });
+            } else if (state.type === 'batching') {
+              state.values.push(res.value);
+            } else {
+              assertNever(state);
+            }
+
+            consumeNext();
+          }
+        },
+        err => {
+          ended = Promise.reject(err);
+
+          if (state.type === 'waiting') {
+            const { reject } = state.resolver;
+            reject(err);
+          }
+        }
+      );
+    }
+
+    consumeNext();
+
+    return {
+      next() {
+        if (state.type === 'batching' && state.values.length > 0) {
+          const { values } = state;
+          state.values = [];
+          return Promise.resolve({ done: false, value: values });
+        }
+
+        if (ended) {
+          return ended;
+        }
+
+        if (state.type === 'waiting') {
+          throw new Error('Previous `next()` is still in progress');
+        }
+
+        return new Promise<IteratorResult<TSource[]>>((resolve, reject) => {
+          state = {
+            type: 'waiting',
+            resolver: { resolve, reject }
+          };
+        });
+      },
+
+      return(value: any) {
+        return it.return
+          ? it.return(value).then(() => ({ done: true } as IteratorResult<TSource[]>))
+          : Promise.resolve({ done: true } as IteratorResult<TSource[]>);
+      }
+    };
+  }
+}
+
+/**
+ * Returns an async iterable sequence of batches that are collected from the source sequence between
+ * subsequent `next()` calls.
+ */
+export function batch<TSource>(source: AsyncIterable<TSource>): AsyncIterableX<TSource[]> {
+  return new BatchAsyncIterable(source);
+}

--- a/src/asynciterable/index.ts
+++ b/src/asynciterable/index.ts
@@ -2,6 +2,7 @@ export * from './asynciterablex';
 export { asyncify } from './asyncify';
 export { asyncifyErrback } from './asyncifyerrback';
 export { average } from './average';
+export { batch } from './batch';
 export { buffer } from './buffer';
 export { _case } from './case';
 export { _catch } from './catch';


### PR DESCRIPTION
This PR adds `AsyncIterableX#batch()` that continuously collects values from the source sequence and returns another sequence of batches. It is somewhat similar to `AsyncSink`, except that it gives back all collected values at once instead of the oldest one.

I've added tests for demonstration purposes. Some edge cases are not covered yet. If this addition fits the project, I'll update them.

There are also a few ways this could be further extended:
* passing a predicate that given a batch tells whether we should suspend collecting values
* passing a custom `reduce` function that collects the batch, e.g. populating a Node.js `Buffer`, or implementing a ring buffer