### PR TITLE
fix: prevent shared iterable from interrupting when breaking from loop

### DIFF
--- a/spec/asynciterable-operators/share-spec.ts
+++ b/spec/asynciterable-operators/share-spec.ts
@@ -54,11 +54,26 @@ test('AsyncIterable#share shared exhausts any time', async (t, [share]) => {
   t.end();
 });
 
+test('AsyncIterable#share shared does not interrupt', async (t, [share]) => {
+  const rng = share(range(0, 5));
+
+  const res1 = await toArray(take(rng, 3));
+  t.true(sequenceEqual(res1, [0, 1, 2]));
+
+  const res2 = await toArray(rng);
+  t.true(sequenceEqual(res2, [3, 4]));
+  t.end();
+});
+
 test('AsyncIterable#share with selector', async (t, [share]) => {
   let n = 0;
   const res = await toArray(
     share(
-      tap(range(0, 10), { next: async () => { n++;} }),
+      tap(range(0, 10), {
+        next: async () => {
+          n++;
+        }
+      }),
       xs => take(zip(([l, r]) => l + r, xs, xs), 4)
     )
   );

--- a/src/asynciterable/share.ts
+++ b/src/asynciterable/share.ts
@@ -6,7 +6,12 @@ class SharedAsyncIterable<T> extends AsyncIterableX<T> {
 
   constructor(it: AsyncIterator<T>) {
     super();
-    this._it = it;
+    // wrap iterator to prevent `return` propagation
+    this._it = {
+      next(value) {
+        return it.next(value);
+      }
+    };
   }
 
   [Symbol.asyncIterator]() {


### PR DESCRIPTION
When iterating over a `share`d AsyncIterable created from a generator function, a `break` statement effectively destroys the shared iterator making it impossible to continue iteration on it later.

This PR updates `share` operator to wrap an iterator disabling its `return` method.

The downside of this is that we won't be able to destroy a shared iterator when we want to. An alternative approach is to add a `detach` operator which simply wraps an iterator.