### PR TITLE
Packaging cleanup, add tee, pipeTo, pipeThrough DOM Streams methods

### DIFF
--- a/gulp/copy-main-task.js
+++ b/gulp/copy-main-task.js
@@ -29,23 +29,25 @@ const { Observable, ReplaySubject } = require('rxjs');
 
 const copyMainTask = ((cache) => memoizeTask(cache, function copyMain(target) {
     const out = targetDir(target);
-    const dtsGlob = `${targetDir(`es2015`, `cjs`)}/**/*.ts`;
-    const cjsGlob = `${targetDir(`es2015`, `cjs`)}/**/*.js`;
+    const dtsGlob = `${targetDir(`esnext`, `cjs`)}/**/*.ts`;
+    const cjsGlob = `${targetDir(`esnext`, `cjs`)}/**/*.js`;
     const esmGlob = `${targetDir(`esnext`, `esm`)}/**/*.js`;
     const es5UmdGlob = `${targetDir(`es5`, `umd`)}/*.js`;
-    const es5UmdMaps = `${targetDir(`es5`, `umd`)}/*.map`;
-    const es2015UmdGlob = `${targetDir(`es2015`, `umd`)}/*.js`;
-    const es2015UmdMaps = `${targetDir(`es2015`, `umd`)}/*.map`;
-    const ch_ext = (ext) => gulpRename((p) => { p.extname = ext; });
-    const append = (ap) => gulpRename((p) => { p.basename += ap; });
+    const esnextUmdGlob = `${targetDir(`esnext`, `umd`)}/*.js`;
+    const cjsSourceMapsGlob = `${targetDir(`esnext`, `cjs`)}/**/*.map`;
+    const esmSourceMapsGlob = `${targetDir(`esnext`, `esm`)}/**/*.map`;
+    const es5UmdSourceMapsGlob = `${targetDir(`es5`, `umd`)}/*.map`;
+    const esnextUmdSourceMapsGlob = `${targetDir(`esnext`, `umd`)}/*.map`;
     return Observable.forkJoin(
-      observableFromStreams(gulp.src(dtsGlob), gulp.dest(out)), // copy d.ts files
-      observableFromStreams(gulp.src(cjsGlob), gulp.dest(out)), // copy es2015 cjs files
-      observableFromStreams(gulp.src(esmGlob), ch_ext(`.mjs`), gulp.dest(out)), // copy es2015 esm files and rename to `.mjs`
-      observableFromStreams(gulp.src(es5UmdGlob), append(`.es5.min`), gulp.dest(out)), // copy es5 umd files and add `.min`
-      observableFromStreams(gulp.src(es5UmdMaps),                     gulp.dest(out)), // copy es5 umd sourcemap files, but don't rename
-      observableFromStreams(gulp.src(es2015UmdGlob), append(`.es2015.min`), gulp.dest(out)), // copy es2015 umd files and add `.es2015.min`
-      observableFromStreams(gulp.src(es2015UmdMaps),                        gulp.dest(out)), // copy es2015 umd sourcemap files, but don't rename
+        observableFromStreams(gulp.src(dtsGlob),                 gulp.dest(out)), // copy d.ts files
+        observableFromStreams(gulp.src(cjsGlob),                 gulp.dest(out)), // copy es2015 cjs files
+        observableFromStreams(gulp.src(cjsSourceMapsGlob),       gulp.dest(out)), // copy es2015 cjs sourcemaps
+        observableFromStreams(gulp.src(esmSourceMapsGlob),       gulp.dest(out)), // copy es2015 esm sourcemaps
+        observableFromStreams(gulp.src(es5UmdSourceMapsGlob),    gulp.dest(out)), // copy es5 umd sourcemap files, but don't rename
+        observableFromStreams(gulp.src(esnextUmdSourceMapsGlob), gulp.dest(out)), // copy es2015 umd sourcemap files, but don't rename
+        observableFromStreams(gulp.src(esmGlob),       gulpRename((p) => { p.extname = '.mjs'; }),          gulp.dest(out)), // copy es2015 esm files and rename to `.mjs`
+        observableFromStreams(gulp.src(es5UmdGlob),    gulpRename((p) => { p.basename += `.es5.min`; }),    gulp.dest(out)), // copy es5 umd files and add `.min`
+        observableFromStreams(gulp.src(esnextUmdGlob), gulpRename((p) => { p.basename += `.es2015.min`; }), gulp.dest(out)), // copy es2015 umd files and add `.es2015.min`
     ).publish(new ReplaySubject()).refCount();
 }))({});
 

--- a/gulp/typescript-task.js
+++ b/gulp/typescript-task.js
@@ -50,9 +50,13 @@ function compileTypescript(out, tsconfigPath, tsconfigOverrides) {
       tsProject(ts.reporter.defaultReporter())
     );
     const writeDTypes = observableFromStreams(dts, gulp.dest(out));
-    const writeJS = observableFromStreams(js, sourcemaps.write(), gulp.dest(out));
+    const mapFile = tsProject.options.module === 5 ? esmMapFile : cjsMapFile;
+    const writeJS = observableFromStreams(js, sourcemaps.write('./', { mapFile }), gulp.dest(out));
     return Observable.forkJoin(writeDTypes, writeJS);
 }
+
+function cjsMapFile(mapFilePath) { return mapFilePath; }
+function esmMapFile(mapFilePath) { return mapFilePath.replace('.js.map', '.mjs.map'); }
 
 module.exports = typescriptTask;
 module.exports.typescriptTask = typescriptTask;

--- a/gulp/util.js
+++ b/gulp/util.js
@@ -122,18 +122,19 @@ function shouldRunInChildProcess(target, format) {
 
 const gulp = path.join(path.parse(require.resolve(`gulp`)).dir, `bin/gulp.js`);
 function spawnGulpCommandInChildProcess(command, target, format) {
-    const args = [gulp, command, '-t', target, '-m', format];
+    const args = [gulp, command, '-t', target, '-m', format, `--silent`];
     const opts = {
         stdio: [`ignore`, `inherit`, `inherit`],
         env: { ...process.env, NODE_NO_WARNINGS: `1` }
     };
-    return asyncDone(() => child_process.spawn(`node`, args, opts));
+    return asyncDone(() => child_process.spawn(`node`, args, opts))
+        .catch((e) => { throw `Error in "${command}:${taskName(target, format)}" task`; });
 }
 
-
+const logAndDie = (e) => { if (e) { process.exit(1) } };
 function observableFromStreams(...streams) {
     if (streams.length <= 0) { return Observable.empty(); }
-    const pumped = streams.length <= 1 ? streams[0] : pump(...streams, (e) => { if (e) { console.error(e); process.exit(1) }});
+    const pumped = streams.length <= 1 ? streams[0] : pump(...streams, logAndDie);
     const fromEvent = Observable.fromEvent.bind(null, pumped);
     const streamObs = fromEvent(`data`)
                .merge(fromEvent(`error`).flatMap((e) => Observable.throw(e)))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -63,9 +63,9 @@ gulp.task(`build:${npmPkgName}`,
     gulp.series(
         gulp.parallel(
             `build:${taskName(`es5`, `umd`)}`,
-            `build:${taskName(`es2015`, `cjs`)}`,
-            `build:${taskName(`es2015`, `esm`)}`,
-            `build:${taskName(`es2015`, `umd`)}`
+            `build:${taskName(`esnext`, `cjs`)}`,
+            `build:${taskName(`esnext`, `esm`)}`,
+            `build:${taskName(`esnext`, `umd`)}`
         ),
         `clean:${npmPkgName}`,
         `compile:${npmPkgName}`,
@@ -81,7 +81,7 @@ gulp.task(`compile`, gulpConcurrent(getTasks(`compile`)));
 gulp.task(`package`, gulpConcurrent(getTasks(`package`)));
 gulp.task(`default`,  gulp.series(`clean`, `build`, `test`));
 
-function gulpConcurrent(tasks, numCPUs = require('os').cpus().length) {
+function gulpConcurrent(tasks, numCPUs = Math.max(1, require('os').cpus().length * 0.5) | 0) {
     return () => Observable.from(tasks.map((task) => gulp.series(task)))
         .flatMap((task) => Observable.bindNodeCallback(task)(), numCPUs || 1);
 }

--- a/src/Ix.dom.ts
+++ b/src/Ix.dom.ts
@@ -18,7 +18,7 @@ export { AsyncSink, Iterable, AsyncIterable } from './Ix';
 
 import './add/asynciterable/fromdomstream';
 import './add/asynciterable-operators/todomstream';
-export { toDOMStream } from './asynciterable/todomstream';
+export { ReadableBYOBStreamOptions, ReadableByteStreamOptions } from './asynciterable/todomstream';
 export {
   fromDOMStream,
   AsyncIterableReadableStream,

--- a/src/Ix.node.ts
+++ b/src/Ix.node.ts
@@ -5,36 +5,3 @@ import './add/asynciterable-operators/tonodestream';
 export { IterableReadable } from './iterable/tonodestream';
 export { AsyncIterableReadable } from './asynciterable/tonodestream';
 export { fromNodeStream, ReadableStreamAsyncIterable } from './asynciterable/fromnodestream';
-
-import { OperatorAsyncFunction } from './interfaces';
-import { AsyncIterableX } from './asynciterable/asynciterablex';
-
-import { toNodeStream } from './asynciterable/tonodestream';
-import { isReadableNodeStream, isWritableNodeStream } from './internal/isiterable';
-
-AsyncIterableX.prototype.pipe = nodePipe;
-
-const as = AsyncIterableX.as;
-const readableOpts = (x: any, opts = x._writableState || { objectMode: true }) => opts;
-type WritableOrOperatorAsyncFunction<T, R> =
-  | NodeJS.WritableStream
-  | NodeJS.ReadWriteStream
-  | OperatorAsyncFunction<T, R>;
-
-function nodePipe<T>(this: AsyncIterableX<T>, ...args: any[]) {
-  let i = -1;
-  let n = args.length;
-  let prev: any = this;
-  let next: WritableOrOperatorAsyncFunction<T, any>;
-  while (++i < n) {
-    next = args[i];
-    if (typeof next === 'function') {
-      prev = as(next(prev));
-    } else if (isWritableNodeStream(next)) {
-      // prettier-ignore
-      return isReadableNodeStream(prev) ? prev.pipe(next) :
-        toNodeStream(prev, readableOpts(next)).pipe(next);
-    }
-  }
-  return prev;
-}

--- a/src/asynciterable/todomstream.ts
+++ b/src/asynciterable/todomstream.ts
@@ -83,7 +83,7 @@ class UnderlyingAsyncIterableByteSource<TSource extends ArrayBufferView = Uint8A
         // Did the source write into the BYOB view itself,
         // then yield us the `bytesWritten` value? If so,
         // pass that along
-        if (typeof value === 'number' && value > 0) {
+        if (typeof value === 'number') {
           return controller.byobRequest.respond(value);
         }
         // otherwise if the source is only producing buffers


### PR DESCRIPTION
Switches the main `ix` package to include `esnext/cjs` and `esnext/esm` by default. Creates external sourcemap files instead of inline. Adds `tee`, `pipeTo`, and `pipeThrough`. Moves the node `pipe` proto override into the `asynciterablex.ts` file so it's accessible if you don't import the top-level module.