### PR TITLE
docs: fix commonjs iterable require example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,8 +29,8 @@ import { from } from 'ix/iterable';
 import { filter, map } from 'ix/iterable/operators';
 
 // CommonJS
-const from = require('ix/asynciterable').from;
-const { filter, map } = require('ix/asynciterable/operators');
+const from = require('ix/iterable').from;
+const { filter, map } = require('ix/iterable/operators');
 
 const source = function* () {
   yield 1;

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ const results = from(source()).pipe(
   map(x => x * x)
 );
 
-for await (let item of results) {
+for (let item of results) {
   console.log(`Next: ${item}`);
 }
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!
-->

**Description:**
The current README specifies the wrong import path for commonjs modules under the Iterables section. This pr just changes asynciterable to iterable

**Related issue (if exists):**
N/A