### PR TITLE
fix(operators): support Array.prototype.reduce signature in Iterable scan and reduce operators again

### DIFF
--- a/spec/iterable-operators/scan-spec.ts
+++ b/spec/iterable-operators/scan-spec.ts
@@ -13,8 +13,31 @@ test('Iterable#scan no seed', () => {
   noNext(it);
 });
 
+test('Iterable#scan no seed Array signature', () => {
+  const res = range(0, 5).pipe(scan((n, x, i) => n + x + i));
+
+  const it = res[Symbol.iterator]();
+  hasNext(it, 2);
+  hasNext(it, 6);
+  hasNext(it, 12);
+  hasNext(it, 20);
+  noNext(it);
+});
+
 test('Iterable#scan with seed', () => {
   const res = range(0, 5).pipe(scan({ callback: (n, x, i) => n - x - i, seed: 20 }));
+
+  const it = res[Symbol.iterator]();
+  hasNext(it, 20);
+  hasNext(it, 18);
+  hasNext(it, 14);
+  hasNext(it, 8);
+  hasNext(it, 0);
+  noNext(it);
+});
+
+test('Iterable#scan with seed Array signature', () => {
+  const res = range(0, 5).pipe(scan((n, x, i) => n - x - i, 20));
 
   const it = res[Symbol.iterator]();
   hasNext(it, 20);

--- a/spec/iterable-operators/scanright-spec.ts
+++ b/spec/iterable-operators/scanright-spec.ts
@@ -24,3 +24,26 @@ test('Iterable#scanRight with seed', () => {
   hasNext(it, 0);
   noNext(it);
 });
+
+test('Iterable#scanRight no seed Array signature', () => {
+  const res = range(0, 5).pipe(scanRight((n, x, i) => n + x + i));
+
+  const it = res[Symbol.iterator]();
+  hasNext(it, 10);
+  hasNext(it, 14);
+  hasNext(it, 16);
+  hasNext(it, 16);
+  noNext(it);
+});
+
+test('Iterable#scanRight with seed Array signature', () => {
+  const res = range(0, 5).pipe(scanRight((n, x, i) => n - x - i, 20));
+
+  const it = res[Symbol.iterator]();
+  hasNext(it, 12);
+  hasNext(it, 6);
+  hasNext(it, 2);
+  hasNext(it, 0);
+  hasNext(it, 0);
+  noNext(it);
+});

--- a/spec/iterable/reduce-spec.ts
+++ b/spec/iterable/reduce-spec.ts
@@ -23,3 +23,15 @@ test('Iterable#reduce with seed empty', () => {
   const ys = reduce(xs, { callback: (x, y, i) => x - y - i, seed: 20 });
   expect(ys).toBe(20);
 });
+
+test('Iterable#reduce no seed Array signature', () => {
+  const xs = of(0, 1, 2, 3, 4);
+  const ys = reduce(xs, (x, y, i) => x + y + i);
+  expect(ys).toBe(20);
+});
+
+test('Iterable#reduce with seed Array signature', () => {
+  const xs = of(0, 1, 2, 3, 4);
+  const ys = reduce(xs, (x, y, i) => x - y - i, 20);
+  expect(ys).toBe(0);
+});

--- a/spec/iterable/reduceright-spec.ts
+++ b/spec/iterable/reduceright-spec.ts
@@ -23,3 +23,15 @@ test('Iterable#reduceRight with seed empty', () => {
   const ys = reduceRight(xs, { callback: (x, y, i) => x - y - i, seed: 20 });
   expect(ys).toBe(20);
 });
+
+test('Iterable#reduceRight no seed Array signature', () => {
+  const xs = of(0, 1, 2, 3, 4);
+  const ys = reduceRight(xs, (x, y, i) => x + y + i);
+  expect(ys).toBe(16);
+});
+
+test('Iterable#reduceRight with seed Array signature', () => {
+  const xs = of(0, 1, 2, 3, 4);
+  const ys = reduceRight(xs, (x, y, i) => x - y - i, 20);
+  expect(ys).toBe(0);
+});

--- a/src/add/iterable-operators/reduce.ts
+++ b/src/add/iterable-operators/reduce.ts
@@ -5,8 +5,26 @@ import { ReduceOptions } from '../../iterable/reduceoptions';
 /**
  * @ignore
  */
-export function reduceProto<T, R = T>(this: IterableX<T>, options: ReduceOptions<T, R>): R {
-  return reduce(this, options);
+export function reduceProto<T, R = T>(this: IterableX<T>, options: ReduceOptions<T, R>): R;
+export function reduceProto<T, R = T>(
+  this: IterableX<T>,
+  accumulator: (accumulator: R, current: T, index: number) => R,
+  seed?: R
+): R;
+export function reduceProto<T, R = T>(
+  this: IterableX<T>,
+  optionsOrAccumulator: ReduceOptions<T, R> | ((accumulator: R, current: T, index: number) => R),
+  seed?: R
+): R {
+  return reduce(
+    this,
+    // eslint-disable-next-line no-nested-ternary
+    typeof optionsOrAccumulator === 'function'
+      ? arguments.length > 1
+        ? { 'callback': optionsOrAccumulator, 'seed': seed }
+        : { 'callback': optionsOrAccumulator }
+      : optionsOrAccumulator
+  );
 }
 
 IterableX.prototype.reduce = reduceProto;

--- a/src/add/iterable-operators/reduceright.ts
+++ b/src/add/iterable-operators/reduceright.ts
@@ -5,8 +5,26 @@ import { ReduceOptions } from '../../iterable/reduceoptions';
 /**
  * @ignore
  */
-export function reduceRightProto<T, R = T>(this: IterableX<T>, options: ReduceOptions<T, R>): R {
-  return reduceRight(this, options);
+export function reduceRightProto<T, R = T>(this: IterableX<T>, options: ReduceOptions<T, R>): R;
+export function reduceRightProto<T, R = T>(
+  this: IterableX<T>,
+  accumulator: (accumulator: R, current: T, index: number) => R,
+  seed?: R
+): R;
+export function reduceRightProto<T, R = T>(
+  this: IterableX<T>,
+  optionsOrAccumulator: ReduceOptions<T, R> | ((accumulator: R, current: T, index: number) => R),
+  seed?: R
+): R {
+  return reduceRight(
+    this,
+    // eslint-disable-next-line no-nested-ternary
+    typeof optionsOrAccumulator === 'function'
+      ? arguments.length > 1
+        ? { 'callback': optionsOrAccumulator, 'seed': seed }
+        : { 'callback': optionsOrAccumulator }
+      : optionsOrAccumulator
+  );
 }
 
 IterableX.prototype.reduceRight = reduceRightProto;

--- a/src/add/iterable-operators/scan.ts
+++ b/src/add/iterable-operators/scan.ts
@@ -5,8 +5,26 @@ import { ScanOptions } from '../../iterable/operators/scanoptions';
 /**
  * @ignore
  */
-export function scanProto<T, R = T>(this: IterableX<T>, options: ScanOptions<T, R>): IterableX<R> {
-  return new ScanIterable(this, options);
+export function scanProto<T, R = T>(this: IterableX<T>, options: ScanOptions<T, R>): IterableX<R>;
+export function scanProto<T, R = T>(
+  this: IterableX<T>,
+  accumulator: (accumulator: R, current: T, index: number) => R,
+  seed?: R
+): IterableX<R>;
+export function scanProto<T, R = T>(
+  this: IterableX<T>,
+  optionsOrAccumulator: ScanOptions<T, R> | ((accumulator: R, current: T, index: number) => R),
+  seed?: R
+): IterableX<R> {
+  return new ScanIterable(
+    this,
+    // eslint-disable-next-line no-nested-ternary
+    typeof optionsOrAccumulator === 'function'
+      ? arguments.length > 1
+        ? { 'callback': optionsOrAccumulator, 'seed': seed }
+        : { 'callback': optionsOrAccumulator }
+      : optionsOrAccumulator
+  );
 }
 
 IterableX.prototype.scan = scanProto;

--- a/src/add/iterable-operators/scanright.ts
+++ b/src/add/iterable-operators/scanright.ts
@@ -8,8 +8,26 @@ import { ScanOptions } from '../../iterable/operators/scanoptions';
 export function scanRightProto<T, R = T>(
   this: IterableX<T>,
   options: ScanOptions<T, R>
+): IterableX<R>;
+export function scanRightProto<T, R = T>(
+  this: IterableX<T>,
+  accumulator: (accumulator: R, current: T, index: number) => R,
+  seed?: R
+): IterableX<R>;
+export function scanRightProto<T, R = T>(
+  this: IterableX<T>,
+  optionsOrAccumulator: ScanOptions<T, R> | ((accumulator: R, current: T, index: number) => R),
+  seed?: R
 ): IterableX<R> {
-  return new ScanRightIterable(this, options);
+  return new ScanRightIterable(
+    this,
+    // eslint-disable-next-line no-nested-ternary
+    typeof optionsOrAccumulator === 'function'
+      ? arguments.length > 1
+        ? { 'callback': optionsOrAccumulator, 'seed': seed }
+        : { 'callback': optionsOrAccumulator }
+      : optionsOrAccumulator
+  );
 }
 
 IterableX.prototype.scanRight = scanRightProto;

--- a/src/iterable/operators/scan.ts
+++ b/src/iterable/operators/scan.ts
@@ -46,7 +46,22 @@ export class ScanIterable<T, R> extends IterableX<R> {
  * @param {ScanOptions<T, R>} options The options including the accumulator function and seed.
  * @returns {OperatorFunction<T, R>} An async-enumerable sequence containing the accumulated values.
  */
-export function scan<T, R = T>(options: ScanOptions<T, R>): OperatorFunction<T, R> {
+export function scan<T, R = T>(options: ScanOptions<T, R>): OperatorFunction<T, R>;
+export function scan<T, R = T>(
+  accumulator: (accumulator: R, current: T, index: number) => R,
+  seed?: R
+): OperatorFunction<T, R>;
+export function scan<T, R = T>(
+  optionsOrAccumulator: ScanOptions<T, R> | ((accumulator: R, current: T, index: number) => R),
+  seed?: R
+): OperatorFunction<T, R> {
+  const options =
+    // eslint-disable-next-line no-nested-ternary
+    typeof optionsOrAccumulator === 'function'
+      ? arguments.length > 1
+        ? { 'callback': optionsOrAccumulator, 'seed': seed }
+        : { 'callback': optionsOrAccumulator }
+      : optionsOrAccumulator;
   return function scanOperatorFunction(source: Iterable<T>): IterableX<R> {
     return new ScanIterable(source, options);
   };

--- a/src/iterable/operators/scanright.ts
+++ b/src/iterable/operators/scanright.ts
@@ -44,7 +44,22 @@ export class ScanRightIterable<T, R> extends IterableX<R> {
  * @param {ScanOptions<T, R>} options The options including the accumulator function and seed.
  * @returns {OperatorAsyncFunction<T, R>} An async-enumerable sequence containing the accumulated values from the right.
  */
-export function scanRight<T, R = T>(options: ScanOptions<T, R>): OperatorFunction<T, R> {
+export function scanRight<T, R = T>(options: ScanOptions<T, R>): OperatorFunction<T, R>;
+export function scanRight<T, R = T>(
+  accumulator: (accumulator: R, current: T, index: number) => R,
+  seed?: R
+): OperatorFunction<T, R>;
+export function scanRight<T, R = T>(
+  optionsOrAccumulator: ScanOptions<T, R> | ((accumulator: R, current: T, index: number) => R),
+  seed?: R
+): OperatorFunction<T, R> {
+  const options =
+    // eslint-disable-next-line no-nested-ternary
+    typeof optionsOrAccumulator === 'function'
+      ? arguments.length > 1
+        ? { 'callback': optionsOrAccumulator, 'seed': seed }
+        : { 'callback': optionsOrAccumulator }
+      : optionsOrAccumulator;
   return function scanRightOperatorFunction(source: Iterable<T>): IterableX<R> {
     return new ScanRightIterable(source, options);
   };

--- a/src/iterable/reduce.ts
+++ b/src/iterable/reduce.ts
@@ -12,12 +12,29 @@ import { ReduceOptions } from './reduceoptions';
  * @param {ReduceOptions<T, R>} options The options which contains a callback and optional seed.
  * @returns {R} The final accumulator value.
  */
-export function reduce<T, R = T>(source: Iterable<T>, options: ReduceOptions<T, R>): R {
-  const { ['seed']: seed, ['callback']: callback } = options;
+export function reduce<T, R = T>(source: Iterable<T>, options: ReduceOptions<T, R>): R;
+export function reduce<T, R = T>(
+  source: Iterable<T>,
+  accumulator: (accumulator: R, current: T, index: number) => R,
+  seed?: R
+): R;
+export function reduce<T, R = T>(
+  source: Iterable<T>,
+  optionsOrAccumulator: ReduceOptions<T, R> | ((accumulator: R, current: T, index: number) => R),
+  seed?: R
+): R {
+  const options =
+    // eslint-disable-next-line no-nested-ternary
+    typeof optionsOrAccumulator === 'function'
+      ? arguments.length > 2
+        ? { 'callback': optionsOrAccumulator, 'seed': seed }
+        : { 'callback': optionsOrAccumulator }
+      : optionsOrAccumulator;
+  const { ['seed']: _seed, ['callback']: callback } = options;
   const hasSeed = options.hasOwnProperty('seed');
   let i = 0;
   let hasValue = false;
-  let acc = seed as T | R;
+  let acc = _seed as T | R;
   for (const item of source) {
     if (hasValue || (hasValue = hasSeed)) {
       acc = callback(<R>acc, item, i++);

--- a/src/iterable/reduceright.ts
+++ b/src/iterable/reduceright.ts
@@ -13,12 +13,29 @@ import { ReduceOptions } from './reduceoptions';
  * @param {ReduceOptions<T, R>} options The options which contains a callback and optional seed.
  * @returns {R} The final accumulator value calculated from the right.
  */
-export function reduceRight<T, R = T>(source: Iterable<T>, options: ReduceOptions<T, R>): R {
-  const { ['seed']: seed, ['callback']: callback } = options;
+export function reduceRight<T, R = T>(source: Iterable<T>, options: ReduceOptions<T, R>): R;
+export function reduceRight<T, R = T>(
+  source: Iterable<T>,
+  accumulator: (accumulator: R, current: T, index: number) => R,
+  seed?: R
+): R;
+export function reduceRight<T, R = T>(
+  source: Iterable<T>,
+  optionsOrAccumulator: ReduceOptions<T, R> | ((accumulator: R, current: T, index: number) => R),
+  seed?: R
+): R {
+  const options =
+    // eslint-disable-next-line no-nested-ternary
+    typeof optionsOrAccumulator === 'function'
+      ? arguments.length > 2
+        ? { 'callback': optionsOrAccumulator, 'seed': seed }
+        : { 'callback': optionsOrAccumulator }
+      : optionsOrAccumulator;
+  const { ['seed']: _seed, ['callback']: callback } = options;
   const hasSeed = options.hasOwnProperty('seed');
   const array = toArray(source);
   let hasValue = false;
-  let acc = seed as T | R;
+  let acc = _seed as T | R;
   for (let offset = array.length - 1; offset >= 0; offset--) {
     const item = array[offset];
     if (hasValue || (hasValue = hasSeed)) {


### PR DESCRIPTION
**Description:**
Support Array.prototype.reduce signature in Iterable scan and reduce operators again

**Related issue (if exists):**
Fix #311
