### PR TITLE
fix(repeat-spec.ts): fix unhandled-rejection error in node v15

### DIFF
--- a/spec/asynciterable-operators/repeat-spec.ts
+++ b/spec/asynciterable-operators/repeat-spec.ts
@@ -1,5 +1,6 @@
 import '../asynciterablehelpers';
-import { from, every, of, sum, toArray } from 'ix/asynciterable';
+import { sum } from 'ix/iterable';
+import { from, every, of, toArray } from 'ix/asynciterable';
 import { buffer, map, repeat, tap, take } from 'ix/asynciterable/operators';
 
 test('AsyncIterable#repeat infinite', async () => {
@@ -19,9 +20,9 @@ test('AsyncIterable#repeat infinite', async () => {
     every(
       from(res).pipe(
         buffer(2),
-        map(b => sum(b))
+        map((b) => sum(b))
       ),
-      x => x === 3
+      { predicate: (x) => x === 3 }
     )
   ).toBeTruthy();
   expect(10).toBe(i);
@@ -41,9 +42,9 @@ test('AsyncIterable#repeat finite', async () => {
     every(
       from(res).pipe(
         buffer(2),
-        map(b => sum(b))
+        map((b) => sum(b))
       ),
-      x => x === 3
+      { predicate: (x) => x === 3 }
     )
   ).toBeTruthy();
   expect(10).toBe(i);


### PR DESCRIPTION
**Description:**
`repeat-spec.ts` was calling `every()` the old way, leading to an unhandled rejection. Unhandled rejections are now errors in node v15, so this was causing CI to fail.
