### PR TITLE
fix(takeUntil): complete iterable immediately (#315)

### DIFF
--- a/spec/asynciterable-operators/takeuntil-spec.ts
+++ b/spec/asynciterable-operators/takeuntil-spec.ts
@@ -1,9 +1,10 @@
 import { hasNext, noNext, delayValue } from '../asynciterablehelpers';
 import { takeUntil } from 'ix/asynciterable/operators';
 import { as } from 'ix/asynciterable';
+import { AsyncSink } from 'ix/asynciterable';
 
 test('AsyncIterable#takeUntil hits', async () => {
-  const xs = async function*() {
+  const xs = async function* () {
     yield await delayValue(1, 100);
     yield await delayValue(2, 300);
     yield await delayValue(3, 1200);
@@ -17,7 +18,7 @@ test('AsyncIterable#takeUntil hits', async () => {
 });
 
 test('AsyncIterable#takeUntil misses', async () => {
-  const xs = async function*() {
+  const xs = async function* () {
     yield await delayValue(1, 100);
     yield await delayValue(2, 300);
     yield await delayValue(3, 600);
@@ -28,5 +29,13 @@ test('AsyncIterable#takeUntil misses', async () => {
   await hasNext(it, 1);
   await hasNext(it, 2);
   await hasNext(it, 3);
+  await noNext(it);
+});
+
+test('AsyncIterable#takeUntil completes immediately', async () => {
+  const sink = new AsyncSink<void>();
+  const ys = as(sink).pipe(takeUntil(() => Promise.resolve()));
+
+  const it = ys[Symbol.asyncIterator]();
   await noNext(it);
 });


### PR DESCRIPTION
**Description:**

Don't wait for a value to be emitted before performing iterable completeness check

**Related issue (if exists):** #315