### PR TITLE
fix(umd): fix the UMD bundle export names so they don't conflict and overwrite each other

### DIFF
--- a/gulp/minify-task.js
+++ b/gulp/minify-task.js
@@ -18,6 +18,7 @@
 const {
     targetDir,
     mainExport,
+    getUMDExportName,
     UMDSourceTargets,
     terserLanguageNames,
     shouldRunInChildProcess,
@@ -57,6 +58,10 @@ const minifyTask = ((cache, commonConfig) => memoizeTask(cache, function minifyJ
     ].map((entry) => ({
         ...targetConfig,
         name: entry,
+        output: {
+            ...targetConfig.output,
+            library: getUMDExportName(entry)
+        },
         entry: { [entry]: path.resolve(`${src}/${entry}.js`) },
         plugins: [
             ...(targetConfig.plugins || []),

--- a/gulp/util.js
+++ b/gulp/util.js
@@ -216,6 +216,12 @@ const esmRequire = require(`esm`)(module, {
     }
 });
 
+const getUMDExportName = (umdEntryFileName) => umdEntryFileName
+    .split('.')
+    .filter((x) => x != 'dom')
+    .map((x) => x[0].toUpperCase() + x.slice(1))
+    .join('');
+
 module.exports = {
 
     mainExport, npmPkgName, npmOrgName, metadataFiles, packageJSONFields,
@@ -224,5 +230,5 @@ module.exports = {
     gCCLanguageNames, UMDSourceTargets, terserLanguageNames,
 
     taskName, packageName, tsconfigName, targetDir, combinations, observableFromStreams,
-    ESKeywords, esmRequire, shouldRunInChildProcess, spawnGulpCommandInChildProcess
+    ESKeywords, esmRequire, shouldRunInChildProcess, spawnGulpCommandInChildProcess, getUMDExportName
 };


### PR DESCRIPTION
Importing multiple UMD bundles into the same page was causing the global Ix object to be replaced
each time, rather than augmented. Exporting them to distinct global objects based on the file name
causes them not to conflict.

Here's an example of something that would currently conflict. Depending on which file was imported, either `from` or `flatMap` wouldn't be available:

```html
<!DOCTYPE html>
<html><body>
<script src="/targets/esnext/umd/Ix.dom.asynciterable.js"></script>
<script src="/targets/esnext/umd/Ix.dom.asynciterable.operators.js"></script>
<script type="text/javascript">
const { from } = IxAsynciterable;
const { flatMap } = IxAsynciterableOperators;
from([0, 1, 2])
  .pipe(flatMap((x) => [x + 1]))
  .forEach((x) => console.log(x))
</script>
</body></html>
```