### PR TITLE
fix(Abort): Ensure removal of event listeners from AbortSignal

### DIFF
--- a/spec/asynciterable/aborting-spec.ts
+++ b/spec/asynciterable/aborting-spec.ts
@@ -1,0 +1,27 @@
+import { interval } from 'ix/asynciterable';
+import '../asynciterablehelpers';
+import { take } from 'ix/asynciterable/operators';
+
+test('Abort signal isn\'t overloaded with event listeners', async () => {
+  const abortController = new AbortController();
+  const listeners: (() => void)[] = [];
+  spyOn(abortController.signal, 'addEventListener').and.callFake((_, listener) =>
+    listeners.push(listener)
+  );
+  spyOn(abortController.signal, 'removeEventListener').and.callFake((_, listener) =>
+    listeners.splice(listeners.indexOf(listener), 1)
+  );
+  await interval(10)
+    .pipe(take(10))
+    .forEach(
+      () => {
+        return;
+      },
+      null,
+      abortController.signal
+    );
+
+  expect(abortController.signal.addEventListener).toHaveBeenCalledTimes(10);
+  expect(abortController.signal.removeEventListener).toHaveBeenCalledTimes(10);
+  expect(listeners).toHaveLength(0);
+});

--- a/spec/asynciterable/aborting-spec.ts
+++ b/spec/asynciterable/aborting-spec.ts
@@ -1,5 +1,5 @@
-import { interval } from 'ix/asynciterable';
 import '../asynciterablehelpers';
+import { interval } from 'ix/asynciterable';
 import { take } from 'ix/asynciterable/operators';
 
 test('Abort signal isn\'t overloaded with event listeners', async () => {

--- a/src/asynciterable/_sleep.ts
+++ b/src/asynciterable/_sleep.ts
@@ -7,22 +7,24 @@ export function sleep(dueTime: number, signal?: AbortSignal) {
     }
 
     const id = setTimeout(() => {
-      if (signal && signal.aborted) {
-        reject(new AbortError());
+      if (signal) {
+        signal.removeEventListener('abort', onAbort);
+        if (signal.aborted) {
+          onAbort();
+          return;
+        }
       }
 
       resolve();
     }, dueTime);
 
     if (signal) {
-      signal.addEventListener(
-        'abort',
-        () => {
-          clearTimeout(id);
-          reject(new AbortError());
-        },
-        { once: true }
-      );
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
+
+    function onAbort() {
+      clearTimeout(id);
+      reject(new AbortError());
     }
   });
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!
-->

**Description:**

I was having problems with using `interval` in tandem with abort signal. It caused a memory leak due to the event listeners not being cleared.

```ts
await interval(100).forEach(()=> {}, null, new AbortController().signal)
```

Running the above code would add a new event listener to the signal every 100ms.

This PR should fix the issue.