### PR TITLE
Fix memory behaviour when using itereables of differing speeds

### DIFF
--- a/src/asynciterable/combinelatest.ts
+++ b/src/asynciterable/combinelatest.ts
@@ -2,6 +2,7 @@ import { AsyncIterableX } from './asynciterablex';
 import { identity } from '../util/identity';
 import { wrapWithAbort } from './operators/withabort';
 import { throwIfAborted } from '../aborterror';
+import { safeRace } from '../util/safeRace';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const NEVER_PROMISE = new Promise(() => {});
@@ -40,7 +41,7 @@ export class CombineLatestAsyncIterable<TSource> extends AsyncIterableX<TSource[
     }
 
     while (active > 0) {
-      const next = Promise.race(nexts);
+      const next = safeRace(nexts);
       const {
         value: { value: value$, done: done$ },
         index,

--- a/src/asynciterable/forkjoin.ts
+++ b/src/asynciterable/forkjoin.ts
@@ -1,6 +1,6 @@
 import { identity } from '../util/identity';
 import { wrapWithAbort } from './operators/withabort';
-import { safeRace } from 'ix/util/safeRace';
+import { safeRace } from '../util/safeRace';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const NEVER_PROMISE = new Promise(() => {});

--- a/src/asynciterable/forkjoin.ts
+++ b/src/asynciterable/forkjoin.ts
@@ -1,5 +1,6 @@
 import { identity } from '../util/identity';
 import { wrapWithAbort } from './operators/withabort';
+import { safeRace } from 'ix/util/safeRace';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const NEVER_PROMISE = new Promise(() => {});
@@ -290,7 +291,7 @@ export async function forkJoin<T>(...sources: any[]): Promise<T[] | undefined> {
   }
 
   while (active > 0) {
-    const next = Promise.race(nexts);
+    const next = safeRace(nexts);
     const { value: next$, index } = await next;
     if (next$.done) {
       nexts[index] = <Promise<MergeResult<IteratorResult<T>>>>NEVER_PROMISE;

--- a/src/asynciterable/fromnodestream.ts
+++ b/src/asynciterable/fromnodestream.ts
@@ -1,4 +1,5 @@
 import { AsyncIterableX } from './asynciterablex';
+import { safeRace } from '../util/safeRace';
 
 const NON_FLOWING = 0;
 const READABLE = 1;
@@ -44,7 +45,7 @@ export class ReadableStreamAsyncIterable extends AsyncIterableX<string | Buffer>
 
   async next(size = this._defaultSize): Promise<IteratorResult<string | Buffer>> {
     if (this._state === NON_FLOWING) {
-      await Promise.race([this._waitReadable(), this._waitEnd()]);
+      await safeRace([this._waitReadable(), this._waitEnd()]);
       return await this.next(size);
     }
 

--- a/src/asynciterable/merge.ts
+++ b/src/asynciterable/merge.ts
@@ -1,6 +1,7 @@
 import { AsyncIterableX } from './asynciterablex';
 import { wrapWithAbort } from './operators/withabort';
 import { throwIfAborted } from '../aborterror';
+import { safeRace } from '../util/safeRace';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const NEVER_PROMISE = new Promise(() => {});
@@ -32,7 +33,7 @@ export class MergeAsyncIterable<T> extends AsyncIterableX<T> {
     }
 
     while (active > 0) {
-      const next = Promise.race(nexts);
+      const next = safeRace(nexts);
       const {
         value: { done: done$, value: value$ },
         index,

--- a/src/asynciterable/operators/takeuntil.ts
+++ b/src/asynciterable/operators/takeuntil.ts
@@ -2,6 +2,7 @@ import { AsyncIterableX } from '../asynciterablex';
 import { MonoTypeOperatorAsyncFunction } from '../../interfaces';
 import { wrapWithAbort } from './withabort';
 import { throwIfAborted } from '../../aborterror';
+import { safeRace } from '../../util/safeRace';
 
 const DONE_PROMISE_VALUE = undefined;
 
@@ -21,7 +22,7 @@ export class TakeUntilAsyncIterable<TSource> extends AsyncIterableX<TSource> {
     const itemsAsyncIterator = wrapWithAbort(this._source, signal)[Symbol.asyncIterator]();
     for (;;) {
       const itemPromise = itemsAsyncIterator.next();
-      const result = await Promise.race([donePromise, itemPromise]);
+      const result = await safeRace([donePromise, itemPromise]);
       if (result === DONE_PROMISE_VALUE || result.done) {
         break;
       }

--- a/src/asynciterable/operators/timeout.ts
+++ b/src/asynciterable/operators/timeout.ts
@@ -4,6 +4,7 @@ import { MonoTypeOperatorAsyncFunction } from '../../interfaces';
 import { wrapWithAbort } from './withabort';
 import { throwIfAborted } from '../../aborterror';
 import { isObject } from '../../util/isiterable';
+import { safeRace } from '../../util/safeRace';
 
 export class TimeoutError extends Error {
   constructor(message: string = 'Timeout has occurred') {
@@ -51,7 +52,7 @@ export class TimeoutAsyncIterable<TSource> extends AsyncIterableX<TSource> {
     throwIfAborted(signal);
     const it = wrapWithAbort(this._source, signal)[Symbol.asyncIterator]();
     while (1) {
-      const { type, value } = await Promise.race<TimeoutOperation<TSource>>([
+      const { type, value } = await safeRace<TimeoutOperation<TSource>>([
         it.next().then((val) => {
           return { type: VALUE_TYPE, val };
         }),

--- a/src/asynciterable/operators/withlatestfrom.ts
+++ b/src/asynciterable/operators/withlatestfrom.ts
@@ -3,6 +3,7 @@ import { OperatorAsyncFunction } from '../../interfaces';
 import { wrapWithAbort } from './withabort';
 import { throwIfAborted } from '../../aborterror';
 import { identity } from '../../util/identity';
+import { safeRace } from '../../util/safeRace';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const NEVER_PROMISE = new Promise(() => {});
@@ -47,7 +48,7 @@ export class WithLatestFromAsyncIterable<TSource> extends AsyncIterableX<TSource
     nexts[length] = wrapPromiseWithIndex(it.next(), length);
 
     for (;;) {
-      const next = Promise.race(nexts);
+      const next = safeRace(nexts);
       const {
         value: { value: value$, done: done$ },
         index,

--- a/src/asynciterable/race.ts
+++ b/src/asynciterable/race.ts
@@ -1,6 +1,7 @@
 import { AsyncIterableX } from './asynciterablex';
 import { wrapWithAbort } from './operators/withabort';
 import { throwIfAborted } from '../aborterror';
+import { safeRace } from 'ix/util/safeRace';
 
 type MergeResult<T> = { value: T; index: number };
 
@@ -30,7 +31,7 @@ export class RaceAsyncIterable<TSource> extends AsyncIterableX<TSource> {
       nexts[i] = wrapPromiseWithIndex(iterator.next(), i);
     }
 
-    const next = Promise.race(nexts);
+    const next = safeRace(nexts);
     const { value: next$, index } = await next;
 
     if (!next$.done) {

--- a/src/asynciterable/race.ts
+++ b/src/asynciterable/race.ts
@@ -1,7 +1,7 @@
 import { AsyncIterableX } from './asynciterablex';
 import { wrapWithAbort } from './operators/withabort';
 import { throwIfAborted } from '../aborterror';
-import { safeRace } from 'ix/util/safeRace';
+import { safeRace } from '../util/safeRace';
 
 type MergeResult<T> = { value: T; index: number };
 

--- a/src/util/safeRace.ts
+++ b/src/util/safeRace.ts
@@ -1,0 +1,67 @@
+function isPrimitive(value: unknown): boolean {
+  return value === null || (typeof value !== 'object' && typeof value !== 'function');
+}
+
+// Keys are the values passed to race, values are a record of data containing a
+// set of deferreds and whether the value has settled.
+const wm = new WeakMap<any, any>();
+export function safeRace<T>(contenders: Promise<T>[]): Promise<T> {
+  let deferred: any;
+  const result = new Promise<T>((resolve, reject) => {
+    deferred = { resolve, reject };
+    for (const contender of contenders) {
+      if (isPrimitive(contender)) {
+        // If the contender is a primitive, attempting to use it as a key in the
+        // weakmap would throw an error. Luckily, it is safe to call
+        // `Promise.resolve(contender).then` on a primitive value multiple times
+        // because the promise fulfills immediately.
+        Promise.resolve(contender).then(resolve, reject);
+        continue;
+      }
+
+      let record = wm.get(contender);
+      if (record === undefined) {
+        record = { deferreds: new Set([deferred]), settled: false };
+        wm.set(contender, record);
+        // This call to `then` happens once for the lifetime of the value.
+        Promise.resolve(contender).then(
+          (value) => {
+            // eslint-disable-next-line no-shadow
+            for (const { resolve } of record.deferreds) {
+              resolve(value);
+            }
+
+            record.deferreds.clear();
+            record.settled = true;
+          },
+          (err) => {
+            // eslint-disable-next-line no-shadow
+            for (const { reject } of record.deferreds) {
+              reject(err);
+            }
+
+            record.deferreds.clear();
+            record.settled = true;
+          }
+        );
+      } else if (record.settled) {
+        // If the value has settled, it is safe to call
+        // `Promise.resolve(contender).then` on it.
+        Promise.resolve(contender).then(resolve, reject);
+      } else {
+        record.deferreds.add(deferred);
+      }
+    }
+  });
+
+  // The finally callback executes when any value settles, preventing any of
+  // the unresolved values from retaining a reference to the resolved value.
+  return result.finally(() => {
+    for (const contender of contenders) {
+      if (!isPrimitive(contender)) {
+        const record = wm.get(contender);
+        record.deferreds.delete(deferred);
+      }
+    }
+  });
+}


### PR DESCRIPTION
I filed #322 Earlier. After some investigation it seems that the behavior observed is spec compliant. Promise.race will keep references until all promises have *settled*.

This PR introduces `safeRace` instead of `Promise.race` which is taken from [here](https://github.com/nodejs/node/issues/17469#issuecomment-685216777) and uses it for merging async iterables. 