### PR TITLE
Buffer Count Or Time operator

### DIFF
--- a/docs/asynciterable/transforming.md
+++ b/docs/asynciterable/transforming.md
@@ -1,0 +1,16 @@
+# Buffer - count or time
+
+An operator that's useful when you need to handle messages in batches.
+Let's say you have an ongoing subscription to something but want to handle batches of messages.
+
+```ts
+await subscription.pipe(
+  // emit when buffer hits 16 items, or every 100ms
+  bufferCountOrTime(16, 100)
+)
+.forEach(handleBatch)
+```
+
+Using this operator makes sure that if messages slow down you'll still 
+handle them in a reasonable time whereas using `buffer` would leave you stuck until you get
+the right amount of messages.

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -152,7 +152,7 @@ This just scratches the surface with the capabilities of using async iterables w
 - Converting AsyncIterables
   - `toArray`, `toDOMStream`, `toMap`, `toNodeStream`, `toObservable`, `toSet`
 - [Transforming Sequences](asynciterable/transforming.md)
-  - `buffer`, `flat`, `flatMap`, `groupBy`, `map`, `pluck`, `scan`, `scanRight`
+  - `buffer`, `bufferCountOrTime`, `flat`, `flatMap`, `groupBy`, `map`, `pluck`, `scan`, `scanRight`
 - Filtering Sequences
   - `debounce`, `distinct`, `distinctUntilChanged`, `elementAt`, `find`, `findIndex`, `first`, `ignoreElements`, `last`, `single`, `slice`
 - Combining Sequences

--- a/spec/asynciterable/buffercountortime-spec.ts
+++ b/spec/asynciterable/buffercountortime-spec.ts
@@ -1,0 +1,28 @@
+import '../asynciterablehelpers';
+import { of, concat } from 'ix/asynciterable';
+import { bufferCountOrTime, delay } from 'ix/asynciterable/operators';
+
+test('buffer count behaviour', async () => {
+  const result: number[][] = [];
+
+  await of(1, 2, 3, 4, 5, 6, 7, 8, 9, 0)
+    .pipe(bufferCountOrTime(5, 10))
+    .forEach((buf) => {
+      result.push(buf);
+    });
+
+  expect(result).toEqual([
+    [1, 2, 3, 4, 5],
+    [6, 7, 8, 9, 0],
+  ]);
+});
+
+test('buffer time behaviour', async () => {
+  const result: number[][] = [];
+  const seq = concat(of(1, 2, 3, 4, 5), of(6, 7, 8, 9), of(0).pipe(delay(11)));
+  await seq.pipe(bufferCountOrTime(5, 10)).forEach((buf) => {
+    result.push(buf);
+  });
+
+  expect(result).toEqual([[1, 2, 3, 4, 5], [6, 7, 8, 9], [0]]);
+});

--- a/src/asynciterable/merge.ts
+++ b/src/asynciterable/merge.ts
@@ -14,12 +14,10 @@ function wrapPromiseWithIndex<T>(promise: Promise<T>, index: number) {
 
 export class MergeAsyncIterable<T> extends AsyncIterableX<T> {
   private _source: AsyncIterable<T>[];
-  private _minActive: number;
 
-  constructor(source: AsyncIterable<T>[], minActive = 0) {
+  constructor(source: AsyncIterable<T>[]) {
     super();
     this._source = source;
-    this._minActive = minActive;
   }
 
   async *[Symbol.asyncIterator](signal?: AbortSignal): AsyncIterator<T> {
@@ -34,7 +32,7 @@ export class MergeAsyncIterable<T> extends AsyncIterableX<T> {
       nexts[i] = wrapPromiseWithIndex(iterator.next(), i);
     }
 
-    while (active > this._minActive) {
+    while (active > 0) {
       const next = safeRace(nexts);
       const {
         value: { done: done$, value: value$ },

--- a/src/asynciterable/merge.ts
+++ b/src/asynciterable/merge.ts
@@ -14,10 +14,12 @@ function wrapPromiseWithIndex<T>(promise: Promise<T>, index: number) {
 
 export class MergeAsyncIterable<T> extends AsyncIterableX<T> {
   private _source: AsyncIterable<T>[];
+  private _minActive: number;
 
-  constructor(source: AsyncIterable<T>[]) {
+  constructor(source: AsyncIterable<T>[], minActive = 0) {
     super();
     this._source = source;
+    this._minActive = minActive;
   }
 
   async *[Symbol.asyncIterator](signal?: AbortSignal): AsyncIterator<T> {
@@ -32,7 +34,7 @@ export class MergeAsyncIterable<T> extends AsyncIterableX<T> {
       nexts[i] = wrapPromiseWithIndex(iterator.next(), i);
     }
 
-    while (active > 0) {
+    while (active > this._minActive) {
       const next = safeRace(nexts);
       const {
         value: { done: done$, value: value$ },

--- a/src/asynciterable/operators/buffercountortime.ts
+++ b/src/asynciterable/operators/buffercountortime.ts
@@ -1,0 +1,64 @@
+import { OperatorAsyncFunction } from '../../interfaces';
+import { AsyncIterableX, interval } from '../';
+import { map } from './map';
+import { MergeAsyncIterable } from '../merge';
+import { wrapWithAbort } from './withabort';
+
+const timerEvent = '__internal_timer_event__' as const;
+
+class BufferCountOrTime<TSource> extends AsyncIterableX<TSource[]> {
+  constructor(
+    private readonly source: AsyncIterable<TSource>,
+    private readonly bufferSize: number,
+    private readonly maxWaitTime: number
+  ) {
+    super();
+  }
+
+  async *[Symbol.asyncIterator](signal?: AbortSignal) {
+    const buffer: TSource[] = [];
+    const timer = interval(this.maxWaitTime).pipe(map(() => timerEvent));
+    const merged = new MergeAsyncIterable<TSource | typeof timerEvent>(
+      [timer, this.source],
+      // we want this merge to end when the source ends
+      // so we set the min active to 1
+      1
+    );
+
+    for await (const item of wrapWithAbort(merged, signal)) {
+      if (item !== timerEvent) {
+        buffer.push(item);
+      }
+      if (buffer.length >= this.bufferSize || (buffer.length && item === timerEvent)) {
+        yield buffer.slice();
+        buffer.length = 0;
+      }
+    }
+
+    if (buffer.length) {
+      yield buffer;
+    }
+  }
+}
+
+/**
+ * Projects each element of an async-iterable sequence into consecutive buffers
+ * which are emitted when either the threshold count or time is met.
+ *
+ * @export
+ * @template TSource The type of elements in the source sequence.
+ * @param {number} count The size of the buffer.
+ * @param {number} time The threshold number of milliseconds to wait before flushing a non-full buffer
+ * @returns {OperatorAsyncFunction<TSource, TSource[]>} An operator which returns an async-iterable sequence
+ * of buffers
+ */
+export function bufferCountOrTime<TSource>(
+  count: number,
+  time: number
+): OperatorAsyncFunction<TSource, TSource[]> {
+  return function bufferOperatorFunction(
+    source: AsyncIterable<TSource>
+  ): AsyncIterableX<TSource[]> {
+    return new BufferCountOrTime<TSource>(source, count, time);
+  };
+}

--- a/src/asynciterable/operators/buffercountortime.ts
+++ b/src/asynciterable/operators/buffercountortime.ts
@@ -4,8 +4,8 @@ import { map } from './map';
 import { merge } from '../merge';
 import { wrapWithAbort } from './withabort';
 
-const timerEvent = '__internal_timer_event__' as const;
-const ended = '__internal_ended_event__' as const;
+const timerEvent = {};
+const ended = {};
 
 class BufferCountOrTime<TSource> extends AsyncIterableX<TSource[]> {
   constructor(

--- a/src/asynciterable/operators/buffercountortime.ts
+++ b/src/asynciterable/operators/buffercountortime.ts
@@ -1,7 +1,7 @@
 import { OperatorAsyncFunction } from '../../interfaces';
 import { AsyncIterableX, interval, concat, of } from '../';
 import { map } from './map';
-import { MergeAsyncIterable } from '../merge';
+import { merge } from '../merge';
 import { wrapWithAbort } from './withabort';
 
 const timerEvent = '__internal_timer_event__' as const;
@@ -20,12 +20,7 @@ class BufferCountOrTime<TSource> extends AsyncIterableX<TSource[]> {
     const buffer: TSource[] = [];
     const timer = interval(this.maxWaitTime).pipe(map(() => timerEvent));
     const source = concat(this.source, of(ended));
-    const merged = new MergeAsyncIterable<TSource | typeof ended | typeof timerEvent>(
-      [timer, source],
-      // we want this merge to end when the source ends
-      // so we set the min active to 1
-      1
-    );
+    const merged = merge(source, timer);
 
     for await (const item of wrapWithAbort(merged, signal)) {
       if (item === ended) {

--- a/src/asynciterable/operators/buffercountortime.ts
+++ b/src/asynciterable/operators/buffercountortime.ts
@@ -4,8 +4,8 @@ import { map } from './map';
 import { merge } from '../merge';
 import { wrapWithAbort } from './withabort';
 
-const timerEvent = {};
-const ended = {};
+const timerEvent = {} as const;
+const ended = {} as const;
 
 class BufferCountOrTime<TSource> extends AsyncIterableX<TSource[]> {
   constructor(

--- a/src/asynciterable/operators/buffercountortime.ts
+++ b/src/asynciterable/operators/buffercountortime.ts
@@ -4,8 +4,8 @@ import { map } from './map';
 import { merge } from '../merge';
 import { wrapWithAbort } from './withabort';
 
-const timerEvent = {} as const;
-const ended = {} as const;
+const timerEvent = {};
+const ended = {};
 
 class BufferCountOrTime<TSource> extends AsyncIterableX<TSource[]> {
   constructor(
@@ -27,7 +27,7 @@ class BufferCountOrTime<TSource> extends AsyncIterableX<TSource[]> {
         break;
       }
       if (item !== timerEvent) {
-        buffer.push(item);
+        buffer.push(item as TSource);
       }
       if (buffer.length >= this.bufferSize || (buffer.length && item === timerEvent)) {
         yield buffer.slice();

--- a/src/asynciterable/operators/index.ts
+++ b/src/asynciterable/operators/index.ts
@@ -1,5 +1,6 @@
 export * from './batch';
 export * from './buffer';
+export * from './buffercountortime';
 export * from './catcherror';
 export * from './combinelatestwith';
 export * from './concatall';


### PR DESCRIPTION
After submitting a few PR's I thought it might be a good idea to share an operator that's been tremendously useful for me.

The scenario I'm dealing with is a subscription (i.e. to a message broker) that emits pretty fast. I'm handling messages from this queue in batches.

Using a plain old `bufferCount` left me in trouble because messages slow down in the evening. During the slowdown some messages would wait a long time in the buffer before being handled (sometimes not until the next day 😱)

I needed an operator that would "flush" the buffer every so often in case of slow messages.

Introducing `bufferCountOrTime` 🎉 

I changed my code from:

```ts
subscription.pipe(
  bufferCount(16)
  // ...
```

to 

```ts
subscription.pipe(
  bufferCountOrTime(16, 1000)
  // ...
```

And all is well! At worst a message waits a second in the buffer before being handled 🚀 