### PR TITLE
Fix #325

### DIFF
--- a/spec/asynciterable-operators/timeout-spec.ts
+++ b/spec/asynciterable-operators/timeout-spec.ts
@@ -1,0 +1,36 @@
+import { hasNext, noNext, delayValue } from '../asynciterablehelpers';
+import { timeout } from 'ix/asynciterable/operators';
+import { as } from 'ix/asynciterable';
+import { TimeoutError } from 'ix/asynciterable/operators/timeout';
+
+test('AsyncIterable#timeout drops none', async () => {
+  const xs = async function* () {
+    yield await delayValue(1, 50);
+    yield await delayValue(2, 50);
+    yield await delayValue(3, 50);
+  };
+  const ys = as(xs()).pipe(timeout(100));
+
+  const it = ys[Symbol.asyncIterator]();
+  await hasNext(it, 1);
+  await hasNext(it, 2);
+  await hasNext(it, 3);
+  await noNext(it);
+});
+
+test('AsyncIterable#timeout throws when delayed', async () => {
+  const xs = async function* () {
+    yield await delayValue(1, 50);
+    yield await delayValue(2, 200);
+  };
+  const ys = as(xs()).pipe(timeout(100));
+
+  const it = ys[Symbol.asyncIterator]();
+  await hasNext(it, 1);
+  try {
+    await it.next();
+  } catch (e) {
+    expect(e).toBeInstanceOf(TimeoutError);
+  }
+  await noNext(it);
+});

--- a/src/asynciterable/operators/timeout.ts
+++ b/src/asynciterable/operators/timeout.ts
@@ -54,7 +54,7 @@ export class TimeoutAsyncIterable<TSource> extends AsyncIterableX<TSource> {
     while (1) {
       const { type, value } = await safeRace<TimeoutOperation<TSource>>([
         it.next().then((val) => {
-          return { type: VALUE_TYPE, val };
+          return { type: VALUE_TYPE, value: val };
         }),
         sleep(this._dueTime, signal).then(() => {
           return { type: ERROR_TYPE };


### PR DESCRIPTION
**Description:**
Typo introduced by linting in a refactor prevented AsyncIterable from passing on its values.

**Related issue (if exists):**
#325
