### PR TITLE
docs(docs/asynciterable/converting.md): Fix fromEventPattern import

### DIFF
--- a/docs/asynciterable/converting.md
+++ b/docs/asynciterable/converting.md
@@ -160,7 +160,7 @@ The other type of binding is `fromEventPattern` which allows you to have an add 
 
 ```typescript
 import { EventEmitter } from 'events';
-import { fromEvent } from 'ix/asynciterable';
+import { fromEventPattern } from 'ix/asynciterable';
 
 function getEvents() {
   const emitter = new EventEmitter();


### PR DESCRIPTION
NOTE: There's a subtle problem that I did not attempt to address in this PR related to module resolution. I've been away from the JS/Node ecosystem for a couple of years (though I'm a longtime fan of Ix!) and in order to run `.js` code (via Node in a terminal) copied from the docs pertaining to this PR, I found I needed to change e.g.
```js
import { fromEventPattern } from 'ix/asynciterable';
```
to
```js
import { fromEventPattern } from 'ix/asynciterable/index.js';
```
And I needed to add `"type": "module"` to `package.json` relative to the scripts I've been using for experimentation.

Alternatively, after adding `"type": "module"` to `package.json`, I could run my scripts by supplying the `--experimental-specifier-resolution=node` option in my terminal, i.e. without changing the `import` statement copied from Ix's docs.

Anyway, just a heads up.