### PR TITLE
add abort signal to 'from' function and fix bug for 'merge' function

### DIFF
--- a/src/asynciterable/merge.ts
+++ b/src/asynciterable/merge.ts
@@ -42,9 +42,9 @@ export class MergeAsyncIterable<T> extends AsyncIterableX<T> {
         nexts[index] = <Promise<MergeResult<IteratorResult<T>>>>NEVER_PROMISE;
         active--;
       } else {
+        yield value$;
         const iterator$ = iterators[index];
         nexts[index] = wrapPromiseWithIndex(iterator$.next(), index);
-        yield value$;
       }
     }
   }


### PR DESCRIPTION
**Description:**
1. from operator doesn't take signal for async iterable source.
2. merge function can cause unhandled rejected promise condition 

**Related issue (if exists):**
1. https://github.com/ReactiveX/IxJS/issues/352
2. https://github.com/ReactiveX/IxJS/issues/353