### PR TITLE
fix(toMap): fix return type of keySelector

### DIFF
--- a/src/add/asynciterable-operators/tomap.ts
+++ b/src/add/asynciterable-operators/tomap.ts
@@ -3,7 +3,7 @@ import { toMap, ToMapOptions } from '../../asynciterable/tomap';
 
 export async function toMapProto<TSource, TKey, TElement = TSource>(
   this: AsyncIterable<TSource>,
-  options: ToMapOptions<TSource, TElement>
+  options: ToMapOptions<TSource, TKey, TElement>
 ): Promise<Map<TKey, TElement | TSource>> {
   return toMap(this, options);
 }

--- a/src/add/iterable-operators/tomap.ts
+++ b/src/add/iterable-operators/tomap.ts
@@ -3,7 +3,7 @@ import { toMap, ToMapOptions } from '../../iterable/tomap';
 
 export function toMapProto<TSource, TKey, TElement = TSource>(
   this: IterableX<TSource>,
-  options: ToMapOptions<TSource, TElement>
+  options: ToMapOptions<TSource, TKey, TElement>
 ): Map<TKey, TElement | TSource> {
   return toMap(this, options);
 }

--- a/src/asynciterable/tomap.ts
+++ b/src/asynciterable/tomap.ts
@@ -10,13 +10,13 @@ import { throwIfAborted } from '../aborterror';
  * @template TElement
  * @ignore
  */
-export interface ToMapOptions<TSource, TElement> {
+export interface ToMapOptions<TSource, TKey, TElement> {
   /**
    * The selector to get the key for the map.
    *
    * @memberof ToMapOptions
    */
-  keySelector: (item: TSource, signal?: AbortSignal) => TElement | Promise<TElement>;
+  keySelector: (item: TSource, signal?: AbortSignal) => TKey | Promise<TKey>;
   /**
    * The selector used to get the element for the Map.
    *
@@ -44,7 +44,7 @@ export interface ToMapOptions<TSource, TElement> {
  */
 export async function toMap<TSource, TKey, TElement = TSource>(
   source: AsyncIterable<TSource>,
-  options: ToMapOptions<TSource, TElement>
+  options: ToMapOptions<TSource, TKey, TElement>
 ): Promise<Map<TKey, TElement | TSource>> {
   const {
     ['signal']: signal,

--- a/src/iterable/tomap.ts
+++ b/src/iterable/tomap.ts
@@ -8,13 +8,13 @@ import { identity } from '../util/identity';
  * @template TElement
  * @ignore
  */
-export interface ToMapOptions<TSource, TElement> {
+export interface ToMapOptions<TSource, TKey, TElement> {
   /**
    * The selector to get the key for the map.
    *
    * @memberof ToMapOptions
    */
-  keySelector: (item: TSource) => TElement;
+  keySelector: (item: TSource) => TKey;
   /**
    * The selector used to get the element for the Map.
    *
@@ -35,7 +35,7 @@ export interface ToMapOptions<TSource, TElement> {
  */
 export function toMap<TSource, TKey, TElement = TSource>(
   source: Iterable<TSource>,
-  options: ToMapOptions<TSource, TElement>
+  options: ToMapOptions<TSource, TKey, TElement>
 ): Map<TKey, TElement | TSource> {
   const {
     ['elementSelector']: elementSelector = identity as any,


### PR DESCRIPTION
change return type of keySelector from TElement to TKey, since keySelector returns keys, not elements

Closes: #364

<!--
Thank you very much for your pull request!
-->

**Description:**
change return type of keySelector to TKey. This might be a breaking change for existing code in rare cases. But then the programmer would very likely have worked around the bug this PR fixes. Feedback welcome.

**Related issue (if exists):**
#364