### PR TITLE
fix(flatmap): flatMap shouldn't throw when the input size is smaller than concurrent

### DIFF
--- a/spec/asynciterable-operators/flatmap-spec.ts
+++ b/spec/asynciterable-operators/flatmap-spec.ts
@@ -9,6 +9,13 @@ test('AsyncIterable#flatMap with range', async () => {
   expect(await toArray(ys)).toEqual([0, 0, 0, 1, 1, 2]);
 });
 
+test(`AsyncIterable#flatMap with fewer inputs than max concurrent doesn't throw`, async () => {
+  const xs = of(1, 2);
+  const ys = xs.pipe(flatMap(async (x) => range(0, x), 3));
+
+  expect(await toArray(ys)).toEqual([0, 0, 1]);
+});
+
 test('AsyncIterable#flatMap selector returns throw', async () => {
   const err = new Error();
   const xs = of(1, 2, 3);

--- a/src/util/returniterator.ts
+++ b/src/util/returniterator.ts
@@ -2,7 +2,7 @@
  * @ignore
  */
 export function returnIterator<T>(it: Iterator<T>) {
-  if (typeof it.return === 'function') {
+  if (typeof it?.return === 'function') {
     it.return();
   }
 }
@@ -11,7 +11,7 @@ export function returnIterator<T>(it: Iterator<T>) {
  * @ignore
  */
 export async function returnAsyncIterator<T>(it: AsyncIterator<T>): Promise<void> {
-  if (typeof it.return === 'function') {
+  if (typeof it?.return === 'function') {
     await it.return();
   }
 }


### PR DESCRIPTION
Fixes #366
