### PR TITLE
fix: ensure catchError functions always return source iterator

### DIFF
--- a/docs/asynciterable/creating.md
+++ b/docs/asynciterable/creating.md
@@ -46,7 +46,7 @@ let value, done;
 
 ## Brief Interlude - `AsyncSink`
 
-Very rarely will we ever need to create these async-iterables by hand, however, if you need a collection that you can add to as well as iterate, we have the `AsyncSink` class.  This class serves as a basis for some of our operators such as binding to events and DOM and Node.js streams.
+Very rarely will we ever need to create these async-iterables by hand, however, if you need a collection that you can add to as well as iterate, we have the `AsyncSink` class. This class serves as a basis for some of our operators such as binding to events and DOM and Node.js streams.
 
 ```typescript
 import { AsyncSink } from 'ix/asynciterable';

--- a/docs/asynciterable/transforming.md
+++ b/docs/asynciterable/transforming.md
@@ -11,6 +11,5 @@ await subscription.pipe(
 .forEach(handleBatch)
 ```
 
-Using this operator makes sure that if messages slow down you'll still 
-handle them in a reasonable time whereas using `buffer` would leave you stuck until you get
+Using this operator makes sure that if messages slow down you'll still handle them in a reasonable time whereas using `buffer` would leave you stuck until you get
 the right amount of messages.

--- a/spec/asynciterable-operators/catcherror-spec.ts
+++ b/spec/asynciterable-operators/catcherror-spec.ts
@@ -1,5 +1,14 @@
+import { jest } from '@jest/globals';
 import '../asynciterablehelpers.js';
-import { of, range, sequenceEqual, single, throwError } from 'ix/asynciterable/index.js';
+import {
+  first,
+  from,
+  of,
+  range,
+  sequenceEqual,
+  single,
+  throwError,
+} from 'ix/asynciterable/index.js';
 import { catchError } from 'ix/asynciterable/operators/index.js';
 
 test('AsyncIterable#catchError error catches', async () => {
@@ -25,4 +34,15 @@ test('AsyncIterable#catchError source and handler types are composed', async () 
   const xs = range(0, 10);
   const res = xs.pipe(catchError(async (_: Error) => of('foo')));
   await expect(sequenceEqual(res, xs)).resolves.toBeTruthy();
+});
+
+test('AsyncIterable#catchError calls return() on source iterator when stopped early', async () => {
+  const xs = range(0, 10)[Symbol.asyncIterator]();
+  const returnSpy = jest.spyOn(xs, 'return');
+
+  const res = from(xs).pipe(catchError((_: Error) => from([])));
+
+  await first(res);
+
+  expect(returnSpy).toHaveBeenCalled();
 });

--- a/spec/asynciterable-operators/skip-spec.ts
+++ b/spec/asynciterable-operators/skip-spec.ts
@@ -1,5 +1,6 @@
+import { jest } from '@jest/globals';
 import { hasNext, noNext } from '../asynciterablehelpers.js';
-import { of, throwError } from 'ix/asynciterable/index.js';
+import { as, first, of, range, throwError } from 'ix/asynciterable/index.js';
 import { skip } from 'ix/asynciterable/operators/index.js';
 
 test('AsyncIterable#skip skips some', async () => {
@@ -39,4 +40,15 @@ test('AsyncIterable#skip throws', async () => {
 
   const it = ys[Symbol.asyncIterator]();
   await expect(it.next()).rejects.toThrow(err);
+});
+
+test('Iterable#skip calls return() on source iterator when stopped early', async () => {
+  const xs = range(0, 10)[Symbol.asyncIterator]();
+  const returnSpy = jest.spyOn(xs, 'return');
+
+  const res = as(xs).pipe(skip(2));
+
+  await first(res);
+
+  expect(returnSpy).toHaveBeenCalled();
 });

--- a/spec/asynciterable/catcherror-spec.ts
+++ b/spec/asynciterable/catcherror-spec.ts
@@ -1,18 +1,28 @@
+import { jest } from '@jest/globals';
+import { skip } from 'ix/asynciterable/operators.js';
 import { hasNext } from '../asynciterablehelpers.js';
-import { catchError, concat, range, sequenceEqual, throwError } from 'ix/asynciterable/index.js';
+import {
+  catchError,
+  concat,
+  first,
+  from,
+  range,
+  sequenceEqual,
+  throwError,
+} from 'ix/asynciterable/index.js';
 
-test('AsyncIterable#catch with no errors', async () => {
+test('AsyncIterable#catchError with no errors', async () => {
   const res = catchError(range(0, 5), range(5, 5));
   expect(await sequenceEqual(res, range(0, 5))).toBeTruthy();
 });
 
-test('AsyncIterable#catch with concat error', async () => {
+test('AsyncIterable#catchError with concat error', async () => {
   const res = catchError(concat(range(0, 5), throwError(new Error())), range(5, 5));
 
   expect(await sequenceEqual(res, range(0, 10))).toBeTruthy();
 });
 
-test('AsyncIterable#catch still throws', async () => {
+test('AsyncIterable#catchError still throws', async () => {
   const e1 = new Error();
   const er1 = throwError(e1);
 
@@ -30,4 +40,18 @@ test('AsyncIterable#catch still throws', async () => {
   await hasNext(it, 2);
   await hasNext(it, 3);
   await expect(it.next()).rejects.toThrow();
+});
+
+test('AsyncIterable#catchError calls return() on source iterator when stopped early', async () => {
+  const e1 = new Error();
+  const er1 = throwError(e1);
+
+  const xs2 = range(2, 2)[Symbol.asyncIterator]();
+  const returnSpy = jest.spyOn(xs2, 'return');
+
+  const res = catchError(concat(range(0, 2), er1), from(xs2)).pipe(skip(2));
+
+  await first(res);
+
+  expect(returnSpy).toHaveBeenCalled();
 });

--- a/spec/iterable-operators/catcherror-spec.ts
+++ b/spec/iterable-operators/catcherror-spec.ts
@@ -1,5 +1,6 @@
+import { jest } from '@jest/globals';
 import '../iterablehelpers';
-import { of, range, sequenceEqual, single, throwError } from 'ix/iterable/index.js';
+import { first, from, of, range, sequenceEqual, single, throwError } from 'ix/iterable/index.js';
 import { catchError } from 'ix/iterable/operators/index.js';
 
 test('Iterable#catchError error catches', () => {
@@ -25,4 +26,15 @@ test('Iterable#catchError source and handler types are composed', () => {
   const xs = range(0, 10);
   const res = xs.pipe(catchError((_: Error) => of('foo')));
   expect(sequenceEqual(res, xs)).toBeTruthy();
+});
+
+test('Iterable#catchError calls return() on source iterator when stopped early', () => {
+  const xs = range(0, 10)[Symbol.iterator]();
+  const returnSpy = jest.spyOn(xs, 'return');
+
+  const res = from(xs).pipe(catchError((_: Error) => from([])));
+
+  first(res);
+
+  expect(returnSpy).toHaveBeenCalled();
 });

--- a/spec/iterable-operators/skip-spec.ts
+++ b/spec/iterable-operators/skip-spec.ts
@@ -1,5 +1,6 @@
+import { jest } from '@jest/globals';
 import { hasNext, noNext } from '../iterablehelpers.js';
-import { as, throwError } from 'ix/iterable/index.js';
+import { as, first, range, throwError } from 'ix/iterable/index.js';
 import { skip } from 'ix/iterable/operators/index.js';
 
 test('Iterable#skip skips some', () => {
@@ -38,4 +39,15 @@ test('Iterable#skip throws', () => {
 
   const it = ys[Symbol.iterator]();
   expect(() => it.next()).toThrow();
+});
+
+test('Iterable#skip calls return() on source iterator when stopped early', () => {
+  const xs = range(0, 10)[Symbol.iterator]();
+  const returnSpy = jest.spyOn(xs, 'return');
+
+  const res = as(xs).pipe(skip(2));
+
+  first(res);
+
+  expect(returnSpy).toHaveBeenCalled();
 });

--- a/spec/iterable/catcherror-spec.ts
+++ b/spec/iterable/catcherror-spec.ts
@@ -1,5 +1,15 @@
+import { jest } from '@jest/globals';
+import { skip } from 'ix/iterable/operators.js';
 import { hasNext } from '../iterablehelpers.js';
-import { catchError, concat, range, sequenceEqual, throwError } from 'ix/iterable/index.js';
+import {
+  from,
+  catchError,
+  concat,
+  range,
+  sequenceEqual,
+  throwError,
+  first,
+} from 'ix/iterable/index.js';
 
 test('Iterable.catchError with no errors', () => {
   const res = catchError(range(0, 5), range(5, 5));
@@ -30,4 +40,18 @@ test('Iterable.catchError still throws', () => {
   hasNext(it, 2);
   hasNext(it, 3);
   expect(() => it.next()).toThrow();
+});
+
+test('Iterable.catchError calls return() on source iterator when stopped early', () => {
+  const e1 = new Error();
+  const er1 = throwError(e1);
+
+  const xs2 = range(2, 2)[Symbol.iterator]();
+  const returnSpy = jest.spyOn(xs2, 'return');
+
+  const res = catchError(concat(range(0, 2), er1), from(xs2)).pipe(skip(2));
+
+  first(res);
+
+  expect(returnSpy).toHaveBeenCalled();
 });

--- a/src/asynciterable/catcherror.ts
+++ b/src/asynciterable/catcherror.ts
@@ -24,24 +24,26 @@ export class CatchAllAsyncIterable<TSource> extends AsyncIterableX<TSource> {
       error = null;
       hasError = false;
 
-      while (1) {
-        let c = <TSource>{};
+      try {
+        while (1) {
+          let c = <TSource>{};
 
-        try {
-          const { done, value } = await it.next();
-          if (done) {
-            await returnAsyncIterator(it);
+          try {
+            const { done, value } = await it.next();
+            if (done) {
+              break;
+            }
+            c = value;
+          } catch (e) {
+            error = e;
+            hasError = true;
             break;
           }
-          c = value;
-        } catch (e) {
-          error = e;
-          hasError = true;
-          await returnAsyncIterator(it);
-          break;
-        }
 
-        yield c;
+          yield c;
+        }
+      } finally {
+        await returnAsyncIterator(it);
       }
 
       if (!hasError) {

--- a/src/asynciterable/operators/skip.ts
+++ b/src/asynciterable/operators/skip.ts
@@ -2,6 +2,7 @@ import { AsyncIterableX } from '../asynciterablex.js';
 import { MonoTypeOperatorAsyncFunction } from '../../interfaces.js';
 import { wrapWithAbort } from './withabort.js';
 import { throwIfAborted } from '../../aborterror.js';
+import { returnAsyncIterator } from '../../util/returniterator.js';
 
 /** @ignore */
 export class SkipAsyncIterable<TSource> extends AsyncIterableX<TSource> {
@@ -20,13 +21,18 @@ export class SkipAsyncIterable<TSource> extends AsyncIterableX<TSource> {
     const it = source[Symbol.asyncIterator]();
     let count = this._count;
     let next;
-    while (count > 0 && !(next = await it.next()).done) {
-      count--;
-    }
-    if (count <= 0) {
-      while (!(next = await it.next()).done) {
-        yield next.value;
+
+    try {
+      while (count > 0 && !(next = await it.next()).done) {
+        count--;
       }
+      if (count <= 0) {
+        while (!(next = await it.next()).done) {
+          yield next.value;
+        }
+      }
+    } finally {
+      returnAsyncIterator(it);
     }
   }
 }

--- a/src/iterable/catcherror.ts
+++ b/src/iterable/catcherror.ts
@@ -20,24 +20,26 @@ export class CatchIterable<TSource> extends IterableX<TSource> {
       error = null;
       hasError = false;
 
-      while (1) {
-        let c = <TSource>{};
+      try {
+        while (1) {
+          let c = <TSource>{};
 
-        try {
-          const { done, value } = it.next();
-          if (done) {
-            returnIterator(it);
+          try {
+            const { done, value } = it.next();
+            if (done) {
+              break;
+            }
+            c = value;
+          } catch (e) {
+            error = e;
+            hasError = true;
             break;
           }
-          c = value;
-        } catch (e) {
-          error = e;
-          hasError = true;
-          returnIterator(it);
-          break;
-        }
 
-        yield c;
+          yield c;
+        }
+      } finally {
+        returnIterator(it);
       }
 
       if (!hasError) {

--- a/src/iterable/operators/catcherror.ts
+++ b/src/iterable/operators/catcherror.ts
@@ -17,24 +17,27 @@ export class CatchWithIterable<TSource, TResult> extends IterableX<TSource | TRe
     let err: Iterable<TResult> | undefined;
     let hasError = false;
     const it = this._source[Symbol.iterator]();
-    while (1) {
-      let done: boolean | undefined;
-      let value: TSource;
 
-      try {
-        ({ done, value } = it.next());
-        if (done) {
-          returnIterator(it);
+    try {
+      while (1) {
+        let done: boolean | undefined;
+        let value: TSource;
+
+        try {
+          ({ done, value } = it.next());
+          if (done) {
+            break;
+          }
+        } catch (e) {
+          err = this._handler(e);
+          hasError = true;
           break;
         }
-      } catch (e) {
-        err = this._handler(e);
-        hasError = true;
-        returnIterator(it);
-        break;
-      }
 
-      yield value;
+        yield value;
+      }
+    } finally {
+      returnIterator(it);
     }
 
     if (hasError) {

--- a/src/iterable/operators/skip.ts
+++ b/src/iterable/operators/skip.ts
@@ -1,5 +1,6 @@
 import { IterableX } from '../iterablex.js';
 import { MonoTypeOperatorFunction } from '../../interfaces.js';
+import { returnIterator } from '../../util/returniterator.js';
 
 /** @ignore */
 export class SkipIterable<TSource> extends IterableX<TSource> {
@@ -16,13 +17,18 @@ export class SkipIterable<TSource> extends IterableX<TSource> {
     const it = this._source[Symbol.iterator]();
     let count = this._count;
     let next;
-    while (count > 0 && !(next = it.next()).done) {
-      count--;
-    }
-    if (count <= 0) {
-      while (!(next = it.next()).done) {
-        yield next.value;
+
+    try {
+      while (count > 0 && !(next = it.next()).done) {
+        count--;
       }
+      if (count <= 0) {
+        while (!(next = it.next()).done) {
+          yield next.value;
+        }
+      }
+    } finally {
+      returnIterator(it);
     }
   }
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!
-->

`catchError` currently swallows return signals. Instead of explicitly returning only if the source iterator is done or an error is thrown, always return it once done. 

I have briefly tried to add unit tests for this, but I couldn't find any other tests for similar behaviour and couldn't manage the juggle to spy on the return function. 