### PR TITLE
Fix memory memory management for flatMap

### DIFF
--- a/src/asynciterable/operators/_flatten.ts
+++ b/src/asynciterable/operators/_flatten.ts
@@ -93,10 +93,12 @@ export class FlattenConcurrentAsyncIterable<TSource, TResult> extends AsyncItera
               }
               if (active < concurrent) {
                 pullNextOuter(value as TSource);
+                results[0] = outer.next();
               } else {
+                // remove the outer iterator from the race, we're full
+                results[0] = NEVER_PROMISE;
                 outerValues.push(value as TSource);
               }
-              results[0] = outer.next();
               break;
             }
             case Type.INNER: {
@@ -119,6 +121,8 @@ export class FlattenConcurrentAsyncIterable<TSource, TResult> extends AsyncItera
             }
             case Type.INNER: {
               --active;
+              // add the outer iterator to the race
+              results[0] = outer.next();
               // return the current slot to the pool
               innerIndices.push(index);
               // synchronously drain the `outerValues` buffer

--- a/src/asynciterable/operators/_flatten.ts
+++ b/src/asynciterable/operators/_flatten.ts
@@ -121,8 +121,10 @@ export class FlattenConcurrentAsyncIterable<TSource, TResult> extends AsyncItera
             }
             case Type.INNER: {
               --active;
-              // add the outer iterator to the race
-              results[0] = outer.next();
+              // add the outer iterator to the race, if its been removed and we are not yet done with it
+              if (results[0] === NEVER_PROMISE && !outerComplete) {
+                results[0] = outer.next();
+              }
               // return the current slot to the pool
               innerIndices.push(index);
               // synchronously drain the `outerValues` buffer


### PR DESCRIPTION
**Description:**

This change prevents us from requesting a value from the outer iterator if we are currently maxed out for concurrency on our inner iterators, This prevents a potential OOM exception where the inner iterators process at a slower rate the the outer iterator can produce.

**Related issue (if exists): #375**