### PR TITLE
feat(interval): option to unref sleep interval

### DIFF
--- a/src/asynciterable/_sleep.ts
+++ b/src/asynciterable/_sleep.ts
@@ -1,7 +1,7 @@
 import { AbortError } from '../aborterror.js';
 
-export function sleep(dueTime: number, signal?: AbortSignal) {
-  return new Promise<void>((resolve, reject) => {
+export function sleep(dueTime: number, signal?: AbortSignal, unref = false): Promise<void> {
+  return new Promise((resolve, reject) => {
     if (signal && signal.aborted) {
       reject(new AbortError());
     }
@@ -17,6 +17,10 @@ export function sleep(dueTime: number, signal?: AbortSignal) {
 
       resolve();
     }, dueTime);
+
+    if (unref && typeof id['unref'] === 'function') {
+      id['unref']();
+    }
 
     if (signal) {
       signal.addEventListener('abort', onAbort, { once: true });

--- a/src/asynciterable/interval.ts
+++ b/src/asynciterable/interval.ts
@@ -4,17 +4,19 @@ import { throwIfAborted } from '../aborterror.js';
 
 class IntervalAsyncIterable extends AsyncIterableX<number> {
   private _dueTime: number;
+  private _unref: boolean;
 
-  constructor(dueTime: number) {
+  constructor(dueTime: number, unref: boolean) {
     super();
     this._dueTime = dueTime;
+    this._unref = unref;
   }
 
   async *[Symbol.asyncIterator](signal?: AbortSignal) {
     throwIfAborted(signal);
     let i = 0;
     while (1) {
-      await sleep(this._dueTime, signal);
+      await sleep(this._dueTime, signal, this._unref);
       yield i++;
     }
   }
@@ -24,8 +26,9 @@ class IntervalAsyncIterable extends AsyncIterableX<number> {
  * Produces a new item in an async-iterable at the given interval cycle time.
  *
  * @param {number} dueTime The due time in milliseconds to spawn a new item.
+ * @param {boolean} [unref=false] Whether to unref the interval timer.
  * @returns {AsyncIterableX<number>} An async-iterable producing values at the specified interval.
  */
-export function interval(dueTime: number): AsyncIterableX<number> {
-  return new IntervalAsyncIterable(dueTime);
+export function interval(dueTime: number, unref = false): AsyncIterableX<number> {
+  return new IntervalAsyncIterable(dueTime, unref);
 }

--- a/src/asynciterable/operators/buffercountortime.ts
+++ b/src/asynciterable/operators/buffercountortime.ts
@@ -18,7 +18,7 @@ class BufferCountOrTime<TSource> extends AsyncIterableX<TSource[]> {
 
   async *[Symbol.asyncIterator](signal?: AbortSignal) {
     const buffer: TSource[] = [];
-    const timer = interval(this.maxWaitTime).pipe(map(() => timerEvent));
+    const timer = interval(this.maxWaitTime, true).pipe(map(() => timerEvent));
     const source = concat(this.source, of(ended));
     const merged = merge(source, timer);
 

--- a/src/asynciterable/operators/timeout.ts
+++ b/src/asynciterable/operators/timeout.ts
@@ -60,7 +60,7 @@ export class TimeoutAsyncIterable<TSource> extends AsyncIterableX<TSource> {
           it.next().then((val) => {
             return { type: VALUE_TYPE, value: val };
           }),
-          sleep(this._dueTime, signal).then(() => {
+          sleep(this._dueTime, signal, true).then(() => {
             return { type: ERROR_TYPE };
           }),
         ]);


### PR DESCRIPTION
Normally, this is not a problem, however when using `bufferCountOrTime()` in unit tests, Jest tends to hang due to the interval used in `sleep()`.

Demo:

```ts
test('x', async () => {
  // Use a longer interval than the Jest timeout to demonstrate "Jest did not exit one second after the test run has completed."
  await from([]).pipe(bufferCountOrTime(0, 10000)).forEach(console.log);
});
```

This PR adds an optional `unref: boolean` parameters that default to the current behaviour. I think it makes sense to unref only in `bufferCountOrTime()` and `timeout()`.

There are currently not really tests for any of the affected files. I would defer coverage of more operators for another PR, if that is okay.