### PR TITLE
feat(bufferCountWithDebounce): add new operator

### DIFF
--- a/spec/asynciterable/buffercountwithdebounce-spec.ts
+++ b/spec/asynciterable/buffercountwithdebounce-spec.ts
@@ -1,11 +1,11 @@
 import '../asynciterablehelpers.js';
-import { of, concat, toArray, interval } from 'ix/asynciterable/index.js';
-import { bufferCountOrTime, delay, take } from 'ix/asynciterable/operators/index.js';
+import { of, concat, interval, toArray } from 'ix/asynciterable/index.js';
+import { bufferCountWithDebounce, delay, take } from 'ix/asynciterable/operators/index.js';
 
 test('buffer count behaviour', async () => {
   const source = of(1, 2, 3, 4, 5, 6, 7, 8, 9, 0);
 
-  const res = source.pipe(bufferCountOrTime(5, 10));
+  const res = source.pipe(bufferCountWithDebounce(5, 10));
 
   expect(await toArray(res)).toEqual([
     [1, 2, 3, 4, 5],
@@ -16,15 +16,18 @@ test('buffer count behaviour', async () => {
 test('buffer time behaviour', async () => {
   const source = concat(of(1, 2, 3, 4, 5), of(6, 7, 8, 9), of(0).pipe(delay(11)));
 
-  const res = source.pipe(bufferCountOrTime(5, 10));
+  const res = source.pipe(bufferCountWithDebounce(5, 10));
 
   expect(await toArray(res)).toEqual([[1, 2, 3, 4, 5], [6, 7, 8, 9], [0]]);
 });
 
-test('continues the timer in the background', async () => {
+test('fills buffers', async () => {
   const source = interval(10);
 
-  const res = source.pipe(bufferCountOrTime(3, 45));
+  const res = source.pipe(bufferCountWithDebounce(3, 45));
 
-  expect(await toArray(res.pipe(take(2)))).toEqual([[0, 1, 2], [3]]);
+  expect(await toArray(res.pipe(take(2)))).toEqual([
+    [0, 1, 2],
+    [3, 4, 5],
+  ]);
 });

--- a/src/asynciterable/operators/buffercountortime.ts
+++ b/src/asynciterable/operators/buffercountortime.ts
@@ -3,6 +3,7 @@ import { AsyncIterableX, interval, concat, of } from '../index.js';
 import { map } from './map.js';
 import { merge } from '../merge.js';
 import { wrapWithAbort } from './withabort.js';
+import type { bufferCountWithDebounce } from './buffercountwithdebounce.js'; // Used only in jsdoc
 
 const timerEvent = {};
 const ended = {};
@@ -44,6 +45,8 @@ class BufferCountOrTime<TSource> extends AsyncIterableX<TSource[]> {
 /**
  * Projects each element of an async-iterable sequence into consecutive buffers
  * which are emitted when either the threshold count or time is met.
+ *
+ * @see https://github.com/ReactiveX/IxJS/pull/380 for the difference between {@link bufferCountOrTime} and {@link bufferCountWithDebounce}.
  *
  * @template TSource The type of elements in the source sequence.
  * @param {number} count The size of the buffer.

--- a/src/asynciterable/operators/buffercountwithdebounce.ts
+++ b/src/asynciterable/operators/buffercountwithdebounce.ts
@@ -1,0 +1,90 @@
+import { OperatorAsyncFunction } from '../../interfaces.js';
+import { AsyncIterableX, concat, of } from '../index.js';
+import { merge } from '../merge.js';
+import { wrapWithAbort } from './withabort.js';
+import { AsyncSink } from '../asyncsink.js';
+import type { bufferCountOrTime } from './buffercountortime.js'; // Used only in jsdoc
+import { sleep } from '../_sleep.js';
+
+const timeoutEvent = Symbol('BufferCountWithDebounce:TimeoutEvent');
+const endedEvent = Symbol('BufferCountWithDebounce:EndedEvent');
+
+class BufferCountWithDebounce<TSource> extends AsyncIterableX<TSource[]> {
+  constructor(
+    private readonly _source: AsyncIterable<TSource>,
+    private readonly _bufferSize: number,
+    private readonly _maxWaitTime: number
+  ) {
+    super();
+  }
+
+  async *[Symbol.asyncIterator](signal?: AbortSignal) {
+    const buffer: TSource[] = [];
+
+    const timeoutSink = new AsyncSink<typeof timeoutEvent>();
+    const merged = merge(concat(this._source, of(endedEvent)), timeoutSink);
+
+    let abortController: AbortController | undefined;
+
+    try {
+      for await (const item of wrapWithAbort(merged, signal)) {
+        if (!abortController) {
+          abortController = new AbortController();
+
+          sleep(this._maxWaitTime, abortController.signal, true)
+            .then(() => {
+              timeoutSink.write(timeoutEvent);
+            })
+            .catch(() => {
+              // Ignore the error if the abort signal is triggered
+            });
+        }
+
+        if (item === endedEvent) {
+          break;
+        }
+
+        if (item !== timeoutEvent) {
+          buffer.push(item);
+        }
+
+        if (buffer.length >= this._bufferSize || (item === timeoutEvent && buffer.length > 0)) {
+          abortController.abort();
+          abortController = undefined;
+
+          yield buffer.slice();
+          buffer.length = 0;
+        }
+      }
+
+      if (buffer.length) {
+        yield buffer;
+      }
+    } finally {
+      abortController?.abort();
+    }
+  }
+}
+
+/**
+ * Projects each element of an async-iterable sequence into consecutive buffers
+ * which are emitted when either the threshold count or time is met.
+ *
+ * @see https://github.com/ReactiveX/IxJS/pull/380 for the difference between {@link bufferCountOrTime} and {@link bufferCountWithDebounce}.
+ *
+ * @template TSource The type of elements in the source sequence.
+ * @param {number} count The size of the buffer.
+ * @param {number} time The threshold number of milliseconds to wait before flushing a non-full buffer
+ * @returns {OperatorAsyncFunction<TSource, TSource[]>} An operator which returns an async-iterable sequence
+ * of buffers
+ */
+export function bufferCountWithDebounce<TSource>(
+  count: number,
+  time: number
+): OperatorAsyncFunction<TSource, TSource[]> {
+  return function bufferOperatorFunction(
+    source: AsyncIterable<TSource>
+  ): AsyncIterableX<TSource[]> {
+    return new BufferCountWithDebounce<TSource>(source, count, time);
+  };
+}

--- a/src/asynciterable/operators/index.ts
+++ b/src/asynciterable/operators/index.ts
@@ -1,6 +1,7 @@
 export * from './batch.js';
 export * from './buffer.js';
 export * from './buffercountortime.js';
+export * from './buffercountwithdebounce.js';
 export * from './catcherror.js';
 export * from './combinelatestwith.js';
 export * from './concatall.js';


### PR DESCRIPTION
Add a new `bufferCountWithDebounce` that is in function very similar to `bufferCountOrTime` with the following difference:

```ts
test('bufferCountOrTime: continues the timer in the background', async () => {
  const source = interval(10);

  const res = source.pipe(bufferCountOrTime(3, 45));

  expect(await toArray(res.pipe(take(2)))).toEqual([[0, 1, 2], [3]]);
});

test('bufferCountWithDebounce: fills buffers', async () => {
  const source = interval(10);

  const res = source.pipe(bufferCountWithDebounce(3, 45));

  expect(await toArray(res.pipe(take(2)))).toEqual([
    [0, 1, 2],
    [3, 4, 5],
  ]);
});
```

While `bufferCountOrTime` keeps the timer running even when no item is currently in the buffer, `bufferCountWithDebounce` instead only starts counting down once the first item of a new batch has been received.

<details>
<summary>Old Description</summary>
This implementation makes a lot more sense to me. Instead of a fixed interval that runs in the background completely unrelated to the source, whenever an item is received and no timer is running, a new timeout is started for the specified time. Either the buffer runs full, in which case the timeout is cleared, and the buffer is yielded, or the timeout fires, and the partially filled buffer is yielded.\
With the current implementations I get a lot of partially filled buffers because e.g:

~Buffer count: 50, buffer window: 5s, source: 10 msg/s, processor: 12.5 msg/s~

~With a pipeline like `source -> buffer (5s) -> processor (4s)`, on the first run, you get a full buffer, but because the interval keeps running, by the time another batch of items is requested (after 4 seconds), the timeout has almost expired and only collects another 10 items (in 1 second).~ The consumer has actually nothing to do with this, see https://github.com/ReactiveX/IxJS/pull/380#issuecomment-2637482058

It makes more sense to me to start the timer once an item arrives and essentially race a full buffer versus the timer firing.

---

Lastly, I think it would make most sense for this operator to keep batching items in the background so that once the consumer requests the next batch, it is already present. But that's a bigger change than this one, so I thought I'd start here.
</details>